### PR TITLE
Add Elm tests

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -28,5 +28,7 @@
         "elm/time": "1.0.0 <= v < 2.0.0",
         "miniBill/elm-fast-dict": "1.0.0 <= v < 2.0.0"
     },
-    "test-dependencies": {}
+    "test-dependencies": {
+        "elm-explorations/test": "2.1.2 <= v < 3.0.0"
+    }
 }

--- a/tests/Context.elm
+++ b/tests/Context.elm
@@ -1,0 +1,123 @@
+module Context exposing (..)
+
+import Expect
+import Fuzz exposing (Fuzzer)
+import Test exposing (..)
+import Internal.Values.Context as Context exposing (Context)
+import Internal.Config.Leaks as Leaks
+import Json.Encode as E
+import Json.Decode as D
+
+
+fuzzer : Fuzzer Context
+fuzzer =
+    let
+        maybeString : Fuzzer (Maybe String)
+        maybeString =
+            Fuzz.maybe Fuzz.string
+    in
+        Fuzz.map7 Context
+            maybeString
+            maybeString
+            maybeString
+            maybeString
+            maybeString
+            maybeString
+            (Fuzz.maybe <| Fuzz.list Fuzz.string)
+
+{-| If a leak is spotted, make sure to change the leaking value and then test
+with the same seed to ensure it is not a (tiny) coincidence and a leak is in
+fact coming through.
+-}
+leaks : Test
+leaks =
+    describe "No leaks allowed"
+        [ fuzz2 fuzzer Fuzz.string "Access token"
+            (\context value ->
+                context
+                    |> Context.apiFormat
+                    |> Context.setAccessToken value
+                    |> Context.getAccessToken
+                    |> Expect.notEqual Leaks.accessToken
+            )
+        , fuzz2 fuzzer Fuzz.string "Base URL"
+            (\context value ->
+                context
+                    |> Context.apiFormat
+                    |> Context.setBaseUrl value
+                    |> Context.getBaseUrl
+                    |> Expect.notEqual Leaks.baseUrl
+            )
+        , fuzz2 fuzzer Fuzz.string "Transaction"
+            (\context value ->
+                context
+                    |> Context.apiFormat
+                    |> Context.setTransaction value
+                    |> Context.getTransaction
+                    |> Expect.notEqual Leaks.transaction
+            )
+        , fuzz2 fuzzer (Fuzz.list Fuzz.string) "Versions"
+            (\context value ->
+                context
+                    |> Context.apiFormat
+                    |> Context.setVersions value
+                    |> Context.getVersions
+                    |> Expect.notEqual Leaks.versions
+            )
+        ]
+
+apiContext : Test
+apiContext =
+    describe "Verify writing info"
+        [ fuzz2 fuzzer Fuzz.string "Access token"
+            (\context value ->
+                context
+                    |> Context.apiFormat
+                    |> Context.setAccessToken value
+                    |> Context.getAccessToken
+                    |> Expect.equal value
+            )
+        , fuzz2 fuzzer Fuzz.string "Base URL"
+            (\context value ->
+                context
+                    |> Context.apiFormat
+                    |> Context.setBaseUrl value
+                    |> Context.getBaseUrl
+                    |> Expect.equal value
+            )
+        , fuzz2 fuzzer Fuzz.string "Transaction"
+            (\context value ->
+                context
+                    |> Context.apiFormat
+                    |> Context.setTransaction value
+                    |> Context.getTransaction
+                    |> Expect.equal value
+            )
+        , fuzz2 fuzzer (Fuzz.list Fuzz.string) "Versions"
+            (\context value ->
+                context
+                    |> Context.apiFormat
+                    |> Context.setVersions value
+                    |> Context.getVersions
+                    |> Expect.equal value
+            )
+        ]
+
+json : Test
+json =
+    describe "JSON encode + JSON decode"
+        [ test "Empty is {}"
+            ( Context.init
+                |> Context.encode
+                |> E.encode 0
+                |> Expect.equal "{}"
+                |> always
+            )
+        , fuzz fuzzer "JSON recode"
+            (\context ->
+                context
+                    |> Context.encode
+                    |> D.decodeValue Context.decoder
+                    |> Expect.equal (Ok context)
+            )
+        ]

--- a/tests/Context.elm
+++ b/tests/Context.elm
@@ -2,11 +2,11 @@ module Context exposing (..)
 
 import Expect
 import Fuzz exposing (Fuzzer)
-import Test exposing (..)
-import Internal.Values.Context as Context exposing (Context)
 import Internal.Config.Leaks as Leaks
-import Json.Encode as E
+import Internal.Values.Context as Context exposing (Context)
 import Json.Decode as D
+import Json.Encode as E
+import Test exposing (..)
 
 
 fuzzer : Fuzzer Context
@@ -16,14 +16,15 @@ fuzzer =
         maybeString =
             Fuzz.maybe Fuzz.string
     in
-        Fuzz.map7 Context
-            maybeString
-            maybeString
-            maybeString
-            maybeString
-            maybeString
-            maybeString
-            (Fuzz.maybe <| Fuzz.list Fuzz.string)
+    Fuzz.map7 Context
+        maybeString
+        maybeString
+        maybeString
+        maybeString
+        maybeString
+        maybeString
+        (Fuzz.maybe <| Fuzz.list Fuzz.string)
+
 
 {-| If a leak is spotted, make sure to change the leaking value and then test
 with the same seed to ensure it is not a (tiny) coincidence and a leak is in
@@ -32,7 +33,9 @@ fact coming through.
 leaks : Test
 leaks =
     describe "No leaks allowed"
-        [ fuzz2 fuzzer Fuzz.string "Access token"
+        [ fuzz2 fuzzer
+            Fuzz.string
+            "Access token"
             (\context value ->
                 context
                     |> Context.apiFormat
@@ -40,7 +43,9 @@ leaks =
                     |> Context.getAccessToken
                     |> Expect.notEqual Leaks.accessToken
             )
-        , fuzz2 fuzzer Fuzz.string "Base URL"
+        , fuzz2 fuzzer
+            Fuzz.string
+            "Base URL"
             (\context value ->
                 context
                     |> Context.apiFormat
@@ -48,7 +53,9 @@ leaks =
                     |> Context.getBaseUrl
                     |> Expect.notEqual Leaks.baseUrl
             )
-        , fuzz2 fuzzer Fuzz.string "Transaction"
+        , fuzz2 fuzzer
+            Fuzz.string
+            "Transaction"
             (\context value ->
                 context
                     |> Context.apiFormat
@@ -56,7 +63,9 @@ leaks =
                     |> Context.getTransaction
                     |> Expect.notEqual Leaks.transaction
             )
-        , fuzz2 fuzzer (Fuzz.list Fuzz.string) "Versions"
+        , fuzz2 fuzzer
+            (Fuzz.list Fuzz.string)
+            "Versions"
             (\context value ->
                 context
                     |> Context.apiFormat
@@ -66,10 +75,13 @@ leaks =
             )
         ]
 
+
 apiContext : Test
 apiContext =
     describe "Verify writing info"
-        [ fuzz2 fuzzer Fuzz.string "Access token"
+        [ fuzz2 fuzzer
+            Fuzz.string
+            "Access token"
             (\context value ->
                 context
                     |> Context.apiFormat
@@ -77,7 +89,9 @@ apiContext =
                     |> Context.getAccessToken
                     |> Expect.equal value
             )
-        , fuzz2 fuzzer Fuzz.string "Base URL"
+        , fuzz2 fuzzer
+            Fuzz.string
+            "Base URL"
             (\context value ->
                 context
                     |> Context.apiFormat
@@ -85,7 +99,9 @@ apiContext =
                     |> Context.getBaseUrl
                     |> Expect.equal value
             )
-        , fuzz2 fuzzer Fuzz.string "Transaction"
+        , fuzz2 fuzzer
+            Fuzz.string
+            "Transaction"
             (\context value ->
                 context
                     |> Context.apiFormat
@@ -93,7 +109,9 @@ apiContext =
                     |> Context.getTransaction
                     |> Expect.equal value
             )
-        , fuzz2 fuzzer (Fuzz.list Fuzz.string) "Versions"
+        , fuzz2 fuzzer
+            (Fuzz.list Fuzz.string)
+            "Versions"
             (\context value ->
                 context
                     |> Context.apiFormat
@@ -103,17 +121,19 @@ apiContext =
             )
         ]
 
+
 json : Test
 json =
     describe "JSON encode + JSON decode"
         [ test "Empty is {}"
-            ( Context.init
+            (Context.init
                 |> Context.encode
                 |> E.encode 0
                 |> Expect.equal "{}"
                 |> always
             )
-        , fuzz fuzzer "JSON recode"
+        , fuzz fuzzer
+            "JSON recode"
             (\context ->
                 context
                     |> Context.encode

--- a/tests/Iddict.elm
+++ b/tests/Iddict.elm
@@ -1,0 +1,249 @@
+module Iddict exposing (..)
+
+import Expect
+import Fuzz exposing (Fuzzer)
+import Internal.Tools.Iddict as Iddict exposing (Iddict)
+import Json.Decode as D
+import Test exposing (..)
+import Json.Encode as E
+import Internal.Tools.Iddict as Iddict
+
+
+fuzzer : Fuzzer a -> Fuzzer (Iddict a)
+fuzzer fuz =
+    fuz
+        |> Fuzz.pair Fuzz.bool
+        |> Fuzz.list
+        |> Fuzz.map
+            (\items ->
+                List.foldl
+                    (\( rm, item ) dict ->
+                        case Iddict.insert item dict of
+                            ( key, d ) ->
+                                if rm then
+                                    Iddict.remove key d
+
+                                else
+                                    d
+                    )
+                    Iddict.empty
+                    items
+            )
+
+
+empty : Test
+empty =
+    describe "empty"
+        [ test "isEmpty"
+            (Iddict.empty
+                |> Iddict.isEmpty
+                |> Expect.equal True
+                |> always
+            )
+        , fuzz Fuzz.int
+            "No members"
+            (\i ->
+                Iddict.empty
+                    |> Iddict.member i
+                    |> Expect.equal False
+            )
+        , fuzz Fuzz.int
+            "Get gets Nothing"
+            (\i ->
+                Iddict.empty
+                    |> Iddict.get i
+                    |> Expect.equal Nothing
+            )
+        , test "Size = 0"
+            (Iddict.empty
+                |> Iddict.size
+                |> Expect.equal 0
+                |> always
+            )
+        , test "No keys"
+            (Iddict.empty
+                |> Iddict.keys
+                |> Expect.equal []
+                |> always
+            )
+        , test "No values"
+            (Iddict.empty
+                |> Iddict.values
+                |> Expect.equal []
+                |> always
+            )
+        , test "JSON encode -> decode -> empty"
+            (Iddict.empty
+                |> Iddict.encode identity
+                |> D.decodeValue (Iddict.decoder D.value)
+                |> Expect.equal (Ok Iddict.empty)
+                |> always
+            )
+        , test "JSON encode"
+            (Iddict.empty
+                |> Iddict.encode identity
+                |> E.encode 0
+                |> Expect.equal "{\"cursor\":0,\"dict\":{}}"
+                |> always
+            )
+        , test "JSON decode"
+            ("{\"cursor\":0,\"dict\":{}}"
+                |> D.decodeString (Iddict.decoder D.value)
+                |> Expect.equal (Ok Iddict.empty)
+                |> always
+            )
+        ]
+
+singleton : Test
+singleton =
+    let
+        singleFuzzer : Fuzzer (Iddict Int)
+        singleFuzzer =
+            Fuzz.map
+                (\i ->
+                    Iddict.singleton i
+                        |> Tuple.second
+                )
+                Fuzz.int
+    in
+        describe "singleton"
+            [ fuzz singleFuzzer "not isEmpty"
+                (\single ->
+                    single
+                        |> Iddict.isEmpty
+                        |> Expect.equal False
+                )
+            , fuzz Fuzz.int "singleton == insert empty"
+                (\i ->
+                    Iddict.empty
+                        |> Iddict.insert i
+                        |> Expect.equal (Iddict.singleton i)
+                )
+            , fuzz Fuzz.int "First item is key 0"
+                (\i ->
+                    Iddict.singleton i
+                        |> Tuple.first
+                        |> Expect.equal 0
+                )
+            , fuzz singleFuzzer "Key 0 is member"
+                (\single ->
+                    single
+                        |> Iddict.member 0
+                        |> Expect.equal True
+                )
+            , fuzz Fuzz.int "Key 0 get returns Just value"
+                (\i ->
+                    Iddict.singleton i
+                        |> Tuple.second
+                        |> Iddict.get 0
+                        |> Expect.equal (Just i)
+                )
+            , fuzz singleFuzzer "Size == 1"
+                (\single ->
+                    single
+                        |> Iddict.size
+                        |> Expect.equal 1
+                )
+            , fuzz Fuzz.int "Only key 0"
+                (\i ->
+                    Iddict.singleton i
+                        |> Tuple.second
+                        |> Iddict.keys
+                        |> Expect.equal [ 0 ]
+                )
+            , fuzz Fuzz.int "Only value value"
+                (\i ->
+                    Iddict.singleton i
+                        |> Tuple.second
+                        |> Iddict.values
+                        |> Expect.equal [ i ]
+                )
+            , fuzz singleFuzzer "JSON encode -> decode -> singleton"
+                (\single ->
+                    single
+                        |> Iddict.encode E.int
+                        |> D.decodeValue (Iddict.decoder D.int)
+                        |> Expect.equal (Ok single)
+                )
+            , fuzz Fuzz.int "JSON encode"
+                (\i ->
+                    Iddict.singleton i
+                        |> Tuple.second
+                        |> Iddict.encode E.int
+                        |> E.encode 0
+                        |> Expect.equal ("{\"cursor\":1,\"dict\":{\"0\":" ++ (String.fromInt i) ++ "}}")
+                )
+            , fuzz Fuzz.int "JSON decode"
+                (\i ->
+                    ("{\"cursor\":1,\"dict\":{\"0\":" ++ (String.fromInt i) ++ "}}")
+                        |> D.decodeString (Iddict.decoder D.int)
+                        |> Tuple.pair 0
+                        |> Expect.equal (Iddict.singleton i |> Tuple.mapSecond Ok)
+                )
+            ]
+
+insert : Test
+insert =
+    describe "insert"
+        [ fuzz2 (fuzzer Fuzz.int) Fuzz.int "Add something"
+            (\d i ->
+                case Iddict.insert i d of
+                    ( key, dict ) ->
+                        dict
+                            |> Iddict.get key
+                            |> Expect.equal (Just i)
+            )
+        , fuzz2 (fuzzer Fuzz.int) Fuzz.int "Never isEmpty"
+            (\d i ->
+                Iddict.insert i d
+                    |> Tuple.second
+                    |> Iddict.isEmpty
+                    |> Expect.equal False
+            )
+        , fuzz2 (fuzzer Fuzz.int) Fuzz.int "New key"
+            (\d i ->
+                case Iddict.insert i d of
+                    ( key, dict ) ->
+                        dict
+                            |> Iddict.remove key
+                            |> Iddict.insert i
+                            |> (\( newKey, _ ) ->
+                                    Expect.notEqual key newKey
+                               )
+            )
+        , fuzz2 (fuzzer Fuzz.int) Fuzz.int "New dict"
+            (\d i ->
+                case Iddict.insert i d of
+                    ( key, dict ) ->
+                        dict
+                            |> Iddict.remove key
+                            |> Iddict.insert i
+                            |> (\( _, newDict ) ->
+                                    Expect.notEqual dict newDict
+                               )
+            )
+        , fuzz2 (fuzzer Fuzz.int) Fuzz.int "Inserted value is member"
+            (\d i ->
+                case Iddict.insert i d of
+                    ( key, dict ) ->
+                        dict
+                            |> Iddict.member key
+                            |> Expect.equal True
+            )
+        , fuzz2 (fuzzer Fuzz.int) Fuzz.int "Get inserted value"
+            (\d i ->
+                case Iddict.insert i d of
+                    ( key, dict ) ->
+                        dict
+                            |> Iddict.get key
+                            |> Expect.equal (Just i)
+            )
+        , fuzz2 (fuzzer Fuzz.int) Fuzz.int "size = size + 1"
+            (\d i ->
+                case Iddict.insert i d of
+                    ( _, dict ) ->
+                        Expect.equal
+                            ( Iddict.size dict )
+                            ( Iddict.size d + 1 )
+            )
+        ]

--- a/tests/Iddict.elm
+++ b/tests/Iddict.elm
@@ -4,9 +4,8 @@ import Expect
 import Fuzz exposing (Fuzzer)
 import Internal.Tools.Iddict as Iddict exposing (Iddict)
 import Json.Decode as D
-import Test exposing (..)
 import Json.Encode as E
-import Internal.Tools.Iddict as Iddict
+import Test exposing (..)
 
 
 fuzzer : Fuzzer a -> Fuzzer (Iddict a)
@@ -94,6 +93,7 @@ empty =
             )
         ]
 
+
 singleton : Test
 singleton =
     let
@@ -106,86 +106,100 @@ singleton =
                 )
                 Fuzz.int
     in
-        describe "singleton"
-            [ fuzz singleFuzzer "not isEmpty"
-                (\single ->
-                    single
-                        |> Iddict.isEmpty
-                        |> Expect.equal False
-                )
-            , fuzz Fuzz.int "singleton == insert empty"
-                (\i ->
-                    Iddict.empty
-                        |> Iddict.insert i
-                        |> Expect.equal (Iddict.singleton i)
-                )
-            , fuzz Fuzz.int "First item is key 0"
-                (\i ->
-                    Iddict.singleton i
-                        |> Tuple.first
-                        |> Expect.equal 0
-                )
-            , fuzz singleFuzzer "Key 0 is member"
-                (\single ->
-                    single
-                        |> Iddict.member 0
-                        |> Expect.equal True
-                )
-            , fuzz Fuzz.int "Key 0 get returns Just value"
-                (\i ->
-                    Iddict.singleton i
-                        |> Tuple.second
-                        |> Iddict.get 0
-                        |> Expect.equal (Just i)
-                )
-            , fuzz singleFuzzer "Size == 1"
-                (\single ->
-                    single
-                        |> Iddict.size
-                        |> Expect.equal 1
-                )
-            , fuzz Fuzz.int "Only key 0"
-                (\i ->
-                    Iddict.singleton i
-                        |> Tuple.second
-                        |> Iddict.keys
-                        |> Expect.equal [ 0 ]
-                )
-            , fuzz Fuzz.int "Only value value"
-                (\i ->
-                    Iddict.singleton i
-                        |> Tuple.second
-                        |> Iddict.values
-                        |> Expect.equal [ i ]
-                )
-            , fuzz singleFuzzer "JSON encode -> decode -> singleton"
-                (\single ->
-                    single
-                        |> Iddict.encode E.int
-                        |> D.decodeValue (Iddict.decoder D.int)
-                        |> Expect.equal (Ok single)
-                )
-            , fuzz Fuzz.int "JSON encode"
-                (\i ->
-                    Iddict.singleton i
-                        |> Tuple.second
-                        |> Iddict.encode E.int
-                        |> E.encode 0
-                        |> Expect.equal ("{\"cursor\":1,\"dict\":{\"0\":" ++ (String.fromInt i) ++ "}}")
-                )
-            , fuzz Fuzz.int "JSON decode"
-                (\i ->
-                    ("{\"cursor\":1,\"dict\":{\"0\":" ++ (String.fromInt i) ++ "}}")
-                        |> D.decodeString (Iddict.decoder D.int)
-                        |> Tuple.pair 0
-                        |> Expect.equal (Iddict.singleton i |> Tuple.mapSecond Ok)
-                )
-            ]
+    describe "singleton"
+        [ fuzz singleFuzzer
+            "not isEmpty"
+            (\single ->
+                single
+                    |> Iddict.isEmpty
+                    |> Expect.equal False
+            )
+        , fuzz Fuzz.int
+            "singleton == insert empty"
+            (\i ->
+                Iddict.empty
+                    |> Iddict.insert i
+                    |> Expect.equal (Iddict.singleton i)
+            )
+        , fuzz Fuzz.int
+            "First item is key 0"
+            (\i ->
+                Iddict.singleton i
+                    |> Tuple.first
+                    |> Expect.equal 0
+            )
+        , fuzz singleFuzzer
+            "Key 0 is member"
+            (\single ->
+                single
+                    |> Iddict.member 0
+                    |> Expect.equal True
+            )
+        , fuzz Fuzz.int
+            "Key 0 get returns Just value"
+            (\i ->
+                Iddict.singleton i
+                    |> Tuple.second
+                    |> Iddict.get 0
+                    |> Expect.equal (Just i)
+            )
+        , fuzz singleFuzzer
+            "Size == 1"
+            (\single ->
+                single
+                    |> Iddict.size
+                    |> Expect.equal 1
+            )
+        , fuzz Fuzz.int
+            "Only key 0"
+            (\i ->
+                Iddict.singleton i
+                    |> Tuple.second
+                    |> Iddict.keys
+                    |> Expect.equal [ 0 ]
+            )
+        , fuzz Fuzz.int
+            "Only value value"
+            (\i ->
+                Iddict.singleton i
+                    |> Tuple.second
+                    |> Iddict.values
+                    |> Expect.equal [ i ]
+            )
+        , fuzz singleFuzzer
+            "JSON encode -> decode -> singleton"
+            (\single ->
+                single
+                    |> Iddict.encode E.int
+                    |> D.decodeValue (Iddict.decoder D.int)
+                    |> Expect.equal (Ok single)
+            )
+        , fuzz Fuzz.int
+            "JSON encode"
+            (\i ->
+                Iddict.singleton i
+                    |> Tuple.second
+                    |> Iddict.encode E.int
+                    |> E.encode 0
+                    |> Expect.equal ("{\"cursor\":1,\"dict\":{\"0\":" ++ String.fromInt i ++ "}}")
+            )
+        , fuzz Fuzz.int
+            "JSON decode"
+            (\i ->
+                ("{\"cursor\":1,\"dict\":{\"0\":" ++ String.fromInt i ++ "}}")
+                    |> D.decodeString (Iddict.decoder D.int)
+                    |> Tuple.pair 0
+                    |> Expect.equal (Iddict.singleton i |> Tuple.mapSecond Ok)
+            )
+        ]
+
 
 insert : Test
 insert =
     describe "insert"
-        [ fuzz2 (fuzzer Fuzz.int) Fuzz.int "Add something"
+        [ fuzz2 (fuzzer Fuzz.int)
+            Fuzz.int
+            "Add something"
             (\d i ->
                 case Iddict.insert i d of
                     ( key, dict ) ->
@@ -193,14 +207,18 @@ insert =
                             |> Iddict.get key
                             |> Expect.equal (Just i)
             )
-        , fuzz2 (fuzzer Fuzz.int) Fuzz.int "Never isEmpty"
+        , fuzz2 (fuzzer Fuzz.int)
+            Fuzz.int
+            "Never isEmpty"
             (\d i ->
                 Iddict.insert i d
                     |> Tuple.second
                     |> Iddict.isEmpty
                     |> Expect.equal False
             )
-        , fuzz2 (fuzzer Fuzz.int) Fuzz.int "New key"
+        , fuzz2 (fuzzer Fuzz.int)
+            Fuzz.int
+            "New key"
             (\d i ->
                 case Iddict.insert i d of
                     ( key, dict ) ->
@@ -211,7 +229,9 @@ insert =
                                     Expect.notEqual key newKey
                                )
             )
-        , fuzz2 (fuzzer Fuzz.int) Fuzz.int "New dict"
+        , fuzz2 (fuzzer Fuzz.int)
+            Fuzz.int
+            "New dict"
             (\d i ->
                 case Iddict.insert i d of
                     ( key, dict ) ->
@@ -222,7 +242,9 @@ insert =
                                     Expect.notEqual dict newDict
                                )
             )
-        , fuzz2 (fuzzer Fuzz.int) Fuzz.int "Inserted value is member"
+        , fuzz2 (fuzzer Fuzz.int)
+            Fuzz.int
+            "Inserted value is member"
             (\d i ->
                 case Iddict.insert i d of
                     ( key, dict ) ->
@@ -230,7 +252,9 @@ insert =
                             |> Iddict.member key
                             |> Expect.equal True
             )
-        , fuzz2 (fuzzer Fuzz.int) Fuzz.int "Get inserted value"
+        , fuzz2 (fuzzer Fuzz.int)
+            Fuzz.int
+            "Get inserted value"
             (\d i ->
                 case Iddict.insert i d of
                     ( key, dict ) ->
@@ -238,12 +262,14 @@ insert =
                             |> Iddict.get key
                             |> Expect.equal (Just i)
             )
-        , fuzz2 (fuzzer Fuzz.int) Fuzz.int "size = size + 1"
+        , fuzz2 (fuzzer Fuzz.int)
+            Fuzz.int
+            "size = size + 1"
             (\d i ->
                 case Iddict.insert i d of
                     ( _, dict ) ->
                         Expect.equal
-                            ( Iddict.size dict )
-                            ( Iddict.size d + 1 )
+                            (Iddict.size dict)
+                            (Iddict.size d + 1)
             )
         ]

--- a/tests/Vault.elm
+++ b/tests/Vault.elm
@@ -1,0 +1,45 @@
+module Vault exposing (..)
+
+import Expect
+import Fuzz exposing (Fuzzer)
+import Matrix
+import Matrix.Settings
+import Test exposing (..)
+import Types
+import Internal.Values.Envelope as Envelope
+import Internal.Config.Default as Default
+
+fuzzer : Fuzzer Matrix.Vault
+fuzzer =
+    Fuzz.constant <| Types.Vault <| Envelope.init {}
+
+settings : Test
+settings =
+    describe "Edit settings"
+        [ fuzz fuzzer "Default device name"
+            (\vault ->
+                vault
+                    |> Matrix.Settings.getDeviceName
+                    |> Expect.equal Default.deviceName
+            )
+        , fuzz2 fuzzer Fuzz.string "Set device name"
+            (\vault name ->
+                vault
+                    |> Matrix.Settings.setDeviceName name
+                    |> Matrix.Settings.getDeviceName
+                    |> Expect.equal name
+            )
+        , fuzz fuzzer "Default sync time"
+            (\vault ->
+                vault
+                    |> Matrix.Settings.getSyncTime
+                    |> Expect.equal Default.syncTime
+            )
+        , fuzz2 fuzzer Fuzz.int "Set sync time"
+            (\vault sync ->
+                vault
+                    |> Matrix.Settings.setSyncTime sync
+                    |> Matrix.Settings.getSyncTime
+                    |> Expect.equal sync
+            )
+        ]

--- a/tests/Vault.elm
+++ b/tests/Vault.elm
@@ -2,40 +2,48 @@ module Vault exposing (..)
 
 import Expect
 import Fuzz exposing (Fuzzer)
+import Internal.Config.Default as Default
+import Internal.Values.Envelope as Envelope
 import Matrix
 import Matrix.Settings
 import Test exposing (..)
 import Types
-import Internal.Values.Envelope as Envelope
-import Internal.Config.Default as Default
+
 
 fuzzer : Fuzzer Matrix.Vault
 fuzzer =
     Fuzz.constant <| Types.Vault <| Envelope.init {}
 
+
 settings : Test
 settings =
     describe "Edit settings"
-        [ fuzz fuzzer "Default device name"
+        [ fuzz fuzzer
+            "Default device name"
             (\vault ->
                 vault
                     |> Matrix.Settings.getDeviceName
                     |> Expect.equal Default.deviceName
             )
-        , fuzz2 fuzzer Fuzz.string "Set device name"
+        , fuzz2 fuzzer
+            Fuzz.string
+            "Set device name"
             (\vault name ->
                 vault
                     |> Matrix.Settings.setDeviceName name
                     |> Matrix.Settings.getDeviceName
                     |> Expect.equal name
             )
-        , fuzz fuzzer "Default sync time"
+        , fuzz fuzzer
+            "Default sync time"
             (\vault ->
                 vault
                     |> Matrix.Settings.getSyncTime
                     |> Expect.equal Default.syncTime
             )
-        , fuzz2 fuzzer Fuzz.int "Set sync time"
+        , fuzz2 fuzzer
+            Fuzz.int
+            "Set sync time"
             (\vault sync ->
                 vault
                     |> Matrix.Settings.setSyncTime sync


### PR DESCRIPTION
After having done some experiments, I have concluded that Elm tests are in fact very helpful to verify the source code.

The branch `elm-test` will remain until proper tests have been written for all relevant modules, but it will ocassionally merge its changes to `develop` to add new guarantees with each upcoming beta version.

This first merge ensures that the new exposed module `Matrix.Settings` has the right tests to guarantee that the functions work as expected.