### PR TITLE
Develop to main for beta 2.0.0

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,23 +3,10 @@
     "name": "noordstar/elm-matrix-sdk-beta",
     "summary": "Matrix SDK for instant communication. Unstable beta version for testing only.",
     "license": "EUPL-1.1",
-    "version": "1.0.0",
+    "version": "2.0.0",
     "exposed-modules": [
         "Matrix",
-        "Matrix.Settings",
-        "Internal.Config.Default",
-        "Internal.Config.Leaks",
-        "Internal.Config.Text",
-        "Internal.Tools.Decode",
-        "Internal.Tools.Encode",
-        "Internal.Tools.Hashdict",
-        "Internal.Tools.Iddict",
-        "Internal.Tools.Timestamp",
-        "Internal.Tools.VersionControl",
-        "Internal.Values.Context",
-        "Internal.Values.Envelope",
-        "Internal.Values.Vault",
-        "Types"
+        "Matrix.Settings"
     ],
     "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {

--- a/src/Internal/Config/Default.elm
+++ b/src/Internal/Config/Default.elm
@@ -23,7 +23,7 @@ will assume until overriden by the user.
 -}
 currentVersion : String
 currentVersion =
-    "beta 1.0.0"
+    "beta 2.0.0"
 
 
 {-| The default device name that is being communicated with the Matrix API.


### PR DESCRIPTION
This pull request allows the `develop` branch to push a new release version to the `main` branch.

In this case, it releases version `2.0.0` based on its changes:

```
This is a MAJOR change.

---- ADDED MODULES - MINOR ----

    Matrix.Settings


---- Matrix - MAJOR ----

    Added:
        type alias Vault = Types.Vault
    
    Removed:
        type Vault
```