### PR TITLE
Update syncTime to be at least 1

### DIFF
--- a/src/Matrix/Settings.elm
+++ b/src/Matrix/Settings.elm
@@ -68,4 +68,4 @@ getSyncTime (Vault vault) =
 -}
 setSyncTime : Int -> Vault -> Vault
 setSyncTime time (Vault vault) =
-    Vault <| Envelope.mapSettings (\s -> { s | syncTime = time }) vault
+    Vault <| Envelope.mapSettings (\s -> { s | syncTime = max 1 time }) vault


### PR DESCRIPTION
# Synctime is at least 1

While I'm working on the `Timeline` data type, this pull request introduces a minor patch to the synctime so that it cannot be called more than once every milisecond.