### PR TITLE
Publish beta 2.1.1

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "noordstar/elm-matrix-sdk-beta",
     "summary": "Matrix SDK for instant communication. Unstable beta version for testing only.",
     "license": "EUPL-1.1",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "exposed-modules": [
         "Matrix",
         "Matrix.Event",

--- a/src/Internal/Config/Default.elm
+++ b/src/Internal/Config/Default.elm
@@ -23,7 +23,7 @@ will assume until overriden by the user.
 -}
 currentVersion : String
 currentVersion =
-    "beta 2.1.0"
+    "beta 2.1.1"
 
 
 {-| The default device name that is being communicated with the Matrix API.

--- a/src/Matrix/Settings.elm
+++ b/src/Matrix/Settings.elm
@@ -68,4 +68,4 @@ getSyncTime (Vault vault) =
 -}
 setSyncTime : Int -> Vault -> Vault
 setSyncTime time (Vault vault) =
-    Vault <| Envelope.mapSettings (\s -> { s | syncTime = time }) vault
+    Vault <| Envelope.mapSettings (\s -> { s | syncTime = max 1 time }) vault

--- a/tests/Test/Matrix/Settings.elm
+++ b/tests/Test/Matrix/Settings.elm
@@ -27,7 +27,7 @@ settings =
                     vault
                         |> Matrix.Settings.setSyncTime sync
                         |> Matrix.Settings.getSyncTime
-                        |> Expect.equal sync
+                        |> Expect.equal (max 1 sync)
                 )
             ]
 


### PR DESCRIPTION
This beta 2.1.1 version presents the following changes:

- Ensured that the synctime is always 1 or higher