### PR TITLE
Add Vault as data type

### DIFF
--- a/src/Internal/Config/Text.elm
+++ b/src/Internal/Config/Text.elm
@@ -126,6 +126,7 @@ docs :
     , timeline : TypeDocs
     , timelineFilter : TypeDocs
     , unsigned : TypeDocs
+    , vault : TypeDocs
     }
 docs =
     { context =
@@ -214,6 +215,12 @@ docs =
         , description =
             [ "Unsigned data is optional data that might come along with the event."
             , "This information is often supportive but not necessary to the context."
+            ]
+        }
+    , vault =
+        { name = "Vault"
+        , description =
+            [ "Main type storing all relevant information from the Matrix API."
             ]
         }
     }
@@ -308,6 +315,10 @@ fields :
         , prevContent : Desc
         , redactedBecause : Desc
         , transactionId : Desc
+        }
+    , vault :
+        { accountData : Desc
+        , rooms : Desc
         }
     }
 fields =
@@ -481,6 +492,14 @@ fields =
             ]
         , transactionId =
             [ "The client-supplied transaction ID, for example, provided via PUT /_matrix/client/v3/rooms/{roomId}/send/{eventType}/{txnId}, if the client being given the event is the same one which sent it."
+            ]
+        }
+    , vault =
+        { accountData =
+            [ "The account's global private data."
+            ]
+        , rooms =
+            [ "Directory of joined rooms that the user is a member of."
             ]
         }
     }

--- a/src/Internal/Tools/Hashdict.elm
+++ b/src/Internal/Tools/Hashdict.elm
@@ -326,7 +326,6 @@ have the originally expected key, it is not updated.
 -}
 update : String -> (Maybe a -> Maybe a) -> Hashdict a -> Hashdict a
 update key f ((Hashdict h) as hd) =
-    -- TODO: Write test for this
     case f (get key hd) of
         Just v ->
             if h.hash v == key then

--- a/src/Internal/Tools/Hashdict.elm
+++ b/src/Internal/Tools/Hashdict.elm
@@ -3,7 +3,7 @@ module Internal.Tools.Hashdict exposing
     , empty, singleton, insert, remove, removeKey
     , isEmpty, member, memberKey, get, size, isEqual
     , keys, values, toList, fromList
-    , rehash, union, map
+    , rehash, union, map, update
     , coder, encode, decoder, softDecoder
     )
 
@@ -35,7 +35,7 @@ This allows you to store values based on an externally defined identifier.
 
 ## Transform
 
-@docs rehash, union, map
+@docs rehash, union, map, update
 
 
 ## JSON coders
@@ -319,6 +319,24 @@ union (Hashdict h1) hd2 =
                 { hash = h1.hash
                 , values = Dict.union h1.values h2.values
                 }
+
+
+{-| Update a dict to maybe contain a value (or not). If the output does not
+have the originally expected key, it is not updated.
+-}
+update : String -> (Maybe a -> Maybe a) -> Hashdict a -> Hashdict a
+update key f ((Hashdict h) as hd) =
+    -- TODO: Write test for this
+    case f (get key hd) of
+        Just v ->
+            if h.hash v == key then
+                insert v hd
+
+            else
+                hd
+
+        Nothing ->
+            removeKey key hd
 
 
 {-| Get all values stored in the hashdict, in the order of their keys.

--- a/src/Internal/Tools/ParserExtra.elm
+++ b/src/Internal/Tools/ParserExtra.elm
@@ -1,8 +1,21 @@
-module Internal.Tools.ParserExtra exposing (..)
+module Internal.Tools.ParserExtra exposing (zeroOrMore, oneOrMore, exactly, atLeast, atMost, times, maxLength)
+
+{-|
+
+
+# Extra parsers
+
+To help the Elm SDK with parsing complex text values, this modules offers a few functions.
+
+@docs zeroOrMore, oneOrMore, exactly, atLeast, atMost, times, maxLength
+
+-}
 
 import Parser as P exposing ((|.), (|=), Parser)
 
 
+{-| Parses an item zero or more times. The result is combined into a list.
+-}
 zeroOrMore : Parser a -> Parser (List a)
 zeroOrMore parser =
     P.loop []
@@ -15,6 +28,9 @@ zeroOrMore parser =
         )
 
 
+{-| Parses an item at least once, but up to any number of times.
+The result is combined into a list.
+-}
 oneOrMore : Parser a -> Parser (List a)
 oneOrMore parser =
     P.succeed (::)
@@ -22,6 +38,9 @@ oneOrMore parser =
         |= zeroOrMore parser
 
 
+{-| Parses an item at least a given number of times, but up to any number.
+The result is combined into a list.
+-}
 atLeast : Int -> Parser a -> Parser (List a)
 atLeast n parser =
     P.loop []
@@ -39,6 +58,10 @@ atLeast n parser =
         )
 
 
+{-| Parses an item any number of times (can be zero), but does not exceed a
+given number of times.
+The result is combined into a list.
+-}
 atMost : Int -> Parser a -> Parser (List a)
 atMost n parser =
     P.loop []
@@ -55,6 +78,10 @@ atMost n parser =
         )
 
 
+{-| Parses an item a given number of times, ranging from the given minimum up
+to the given maximum.
+The result is combined into a list.
+-}
 times : Int -> Int -> Parser a -> Parser (List a)
 times inf sup parser =
     let
@@ -84,11 +111,21 @@ times inf sup parser =
         )
 
 
+{-| Repeat pasing an item an exact number of times.
+The result is combined into a list.
+-}
 exactly : Int -> Parser a -> Parser (List a)
 exactly n =
     times n n
 
 
+{-| After having parsed the item, make sure that the parsed text has not
+exceeded a given length. If so, the parser fails.
+
+This modification can be useful if a text has a maximum length requirement -
+for example, usernames on Matrix cannot have a length of over 255 characters.
+
+-}
 maxLength : Int -> Parser a -> Parser a
 maxLength n parser =
     P.succeed

--- a/src/Internal/Values/Vault.elm
+++ b/src/Internal/Values/Vault.elm
@@ -1,13 +1,74 @@
-module Internal.Values.Vault exposing (Vault)
+module Internal.Values.Vault exposing
+    ( fromRoomId, mapRoom, updateRoom
+    , getAccountData, setAccountData
+    , Vault
+    )
 
-{-| This module hosts the Vault module.
+{-| This module hosts the Vault module. The Vault is the data type storing all
+credentials, all user information and all other information that the user
+can receive from the Matrix API.
 
-@docs Vault
+
+
+
+## Rooms
+
+Rooms are environments where people can have a conversation with each other.
+
+@docs fromRoomId, mapRoom, updateRoom
+
+
+## Account data
+
+@docs getAccountData, setAccountData
 
 -}
+
+import FastDict as Dict exposing (Dict)
+import Internal.Tools.Hashdict as Hashdict exposing (Hashdict)
+import Internal.Tools.Json as Json
+import Internal.Values.Room exposing (Room)
 
 
 {-| This is the Vault type.
 -}
 type alias Vault =
-    ()
+    { accountData : Dict String Json.Value
+    , rooms : Hashdict Room
+    }
+
+
+{-| Get a given room by its room id.
+-}
+fromRoomId : String -> Vault -> Maybe Room
+fromRoomId roomId vault =
+    Hashdict.get roomId vault.rooms
+
+
+{-| Get a piece of account data as information from the room.
+-}
+getAccountData : String -> Vault -> Maybe Json.Value
+getAccountData key vault =
+    Dict.get key vault.accountData
+
+
+{-| Update a room, if it exists. If the room isn´t known, this operation is
+ignored.
+-}
+mapRoom : String -> (Room -> Room) -> Vault -> Vault
+mapRoom roomId f vault =
+    { vault | rooms = Hashdict.map roomId f vault.rooms }
+
+
+{-| Set a piece of account data as information in the global vault data.
+-}
+setAccountData : String -> Json.Value -> Vault -> Vault
+setAccountData key value vault =
+    { vault | accountData = Dict.insert key value vault.accountData }
+
+
+{-| Update a Room based on whether it exists or not.
+-}
+updateRoom : String -> (Maybe Room -> Maybe Room) -> Vault -> Vault
+updateRoom roomId f vault =
+    { vault | rooms = Hashdict.update roomId f vault.rooms }

--- a/src/Matrix.elm
+++ b/src/Matrix.elm
@@ -1,4 +1,7 @@
-module Matrix exposing (Vault)
+module Matrix exposing
+    ( Vault
+    , VaultUpdate, update
+    )
 
 {-|
 
@@ -17,9 +20,16 @@ support a monolithic public registry. (:
 
 @docs Vault
 
+
+## Keeping the Vault up-to-date
+
+@docs VaultUpdate, update
+
 -}
 
-import Types
+import Internal.Values.Envelope as Envelope
+import Internal.Values.Vault as Internal
+import Types exposing (Vault(..), VaultUpdate(..))
 
 
 {-| The Vault type stores all relevant information about the Matrix API.
@@ -30,3 +40,22 @@ the latest information about an account.
 -}
 type alias Vault =
     Types.Vault
+
+
+{-| The VaultUpdate type is the central type that keeps the Vault up-to-date.
+-}
+type alias VaultUpdate =
+    Types.VaultUpdate
+
+
+{-| Using new VaultUpdate information, update the Vault accordingly.
+
+This allows us to change our perception of the Matrix environment: has anyone
+sent a new message? Did someone send us an invite for a new room?
+
+-}
+update : VaultUpdate -> Vault -> Vault
+update (VaultUpdate vu) (Vault vault) =
+    vault
+        |> Envelope.update Internal.update vu
+        |> Vault

--- a/src/Matrix.elm
+++ b/src/Matrix.elm
@@ -8,8 +8,8 @@ module Matrix exposing
 
 # Matrix SDK
 
-This first version forms a mere basis from which we will create iterative builds
-that slowly improve the codebase.
+This library forms a mere basis from which an entire functional SDK is
+developed for the Matrix protocol.
 
 It is generally quite unusual to regularly publish iterative beta versions on
 the public registry, but it is also generally quite unusual to exclusively

--- a/src/Matrix.elm
+++ b/src/Matrix.elm
@@ -24,7 +24,8 @@ import Types
 
 {-| The Vault type stores all relevant information about the Matrix API.
 
-It currently supports no functionality and it will just stay here - for fun.
+If you make sure that the data type stays up-to-date, you can use it to explore
+the latest information about an account.
 
 -}
 type alias Vault =

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -1,4 +1,4 @@
-module Types exposing (Vault(..), Event(..), Room(..), User(..))
+module Types exposing (Vault(..), Event(..), Room(..), User(..), VaultUpdate(..))
 
 {-| The Elm SDK uses a lot of records and values that are easy to manipulate.
 Yet, the [Elm design guidelines](https://package.elm-lang.org/help/design-guidelines#keep-tags-and-record-constructors-secret)
@@ -12,7 +12,7 @@ access their content directly.
 The opaque types are placed in a central module so all exposed modules can
 safely access all exposed data types without risking to create circular imports.
 
-@docs Vault, Event, Room, User
+@docs Vault, Event, Room, User, VaultUpdate
 
 -}
 
@@ -45,3 +45,9 @@ type User
 -}
 type Vault
     = Vault (Envelope.Envelope Vault.Vault)
+
+
+{-| Opaque type for Matrix VaultUpdate
+-}
+type VaultUpdate
+    = VaultUpdate (Envelope.EnvelopeUpdate Vault.VaultUpdate)

--- a/tests/Test/Tools/Hashdict.elm
+++ b/tests/Test/Tools/Hashdict.elm
@@ -103,7 +103,7 @@ suite =
             ]
         , describe "singleton"
             [ fuzz TestEvent.fuzzer
-                "singletong = empty + insert"
+                "singleton = empty + insert"
                 (\event ->
                     Hashdict.empty .eventId
                         |> Hashdict.insert event
@@ -157,6 +157,26 @@ suite =
                         Hashdict.singleton .eventId event
                             |> Hashdict.memberKey event.roomId
                             |> Expect.equal False
+                )
+            ]
+        , describe "update"
+            [ fuzz2 (fuzzer identity Fuzz.string)
+                Fuzz.string
+                "add = insert"
+                (\hashdict value ->
+                    Hashdict.isEqual
+                        (Hashdict.insert value hashdict)
+                        (Hashdict.update value (always (Just value)) hashdict)
+                        |> Expect.equal True
+                )
+            , fuzz2 (fuzzer identity Fuzz.string)
+                Fuzz.string
+                "remove = removeKey"
+                (\hashdict value ->
+                    Hashdict.isEqual
+                        (Hashdict.removeKey value hashdict)
+                        (Hashdict.update value (always Nothing) hashdict)
+                        |> Expect.equal True
                 )
             ]
         , describe "JSON"

--- a/tests/Test/Values/Vault.elm
+++ b/tests/Test/Values/Vault.elm
@@ -1,10 +1,20 @@
 module Test.Values.Vault exposing (..)
 
+import FastDict as Dict exposing (Dict)
 import Fuzz exposing (Fuzzer)
+import Internal.Tools.Json as Json
 import Internal.Values.Vault exposing (Vault)
 import Test exposing (..)
+import Test.Tools.Hashdict as TestHashdict
+import Test.Values.Room as TestRoom
 
 
 vault : Fuzzer Vault
 vault =
-    Fuzz.unit
+    Fuzz.map2 Vault
+        (Fuzz.string
+            |> Fuzz.map (\k -> ( k, Json.encode Json.int 0 ))
+            |> Fuzz.list
+            |> Fuzz.map Dict.fromList
+        )
+        (TestHashdict.fuzzer .roomId TestRoom.fuzzer)


### PR DESCRIPTION
The `Vault` type is the central type of the Elm SDK. All functionality revolves around it.

This pull request refactors the placeholder type into a basic functional type that can interact with an API and store data.

Additionally, this pull request adds a `VaultUpdate` type to update the `Vault` type with information from the Matrix API.