### PR TITLE
Publish beta 3.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ supported for which spec versions.
 - ✅ **One way to do things** instead of having multiple functions that are
 considered deprecated.
 
-Follow us on [Mastodon](https://social.noordstar.me/@elm_matrix_sdk) at
-@elm_matrix_sdk@social.noordstar.me to stay up-to-date on the latest changes.
+Follow us on [Mastodon](https://social.noordstar.me/@elm_matrix_sdk) or join the
+conversation on [Matrix](https://matrix.to/#/#elm-sdk:matrix.org) to stay
+up-to-date on the latest changes.
 
 ## How to install
 

--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "noordstar/elm-matrix-sdk-beta",
     "summary": "Matrix SDK for instant communication. Unstable beta version for testing only.",
     "license": "EUPL-1.1",
-    "version": "3.3.0",
+    "version": "3.3.1",
     "exposed-modules": [
         "Matrix",
         "Matrix.Event",

--- a/src/Internal/Config/Default.elm
+++ b/src/Internal/Config/Default.elm
@@ -29,7 +29,7 @@ will assume until overriden by the user.
 -}
 currentVersion : String
 currentVersion =
-    "beta 3.3.0"
+    "beta 3.3.1"
 
 
 {-| The default device name that is being communicated with the Matrix API.

--- a/src/Internal/Config/Text.elm
+++ b/src/Internal/Config/Text.elm
@@ -609,7 +609,8 @@ happened. Most of these unexpected results, are taken account of by the Elm SDK,
 but logged so that the programmer can do something about it.
 -}
 logs :
-    { baseUrlFound : String -> String -> String
+    { baseUrlFailed : String -> String
+    , baseUrlFound : String -> String -> String
     , getEventId : String -> String
     , getNow : Int -> String
     , httpRequest : String -> String -> String
@@ -621,7 +622,9 @@ logs :
     , serverReturnedUnknownJSON : String -> String
     }
 logs =
-    { baseUrlFound =
+    { baseUrlFailed =
+        (++) "Failed to find .well-known, using default server address: "
+    , baseUrlFound =
         \url baseUrl ->
             String.concat [ "Found baseURL of ", url, " at address ", baseUrl ]
     , getEventId = (++) "Received event with id = "


### PR DESCRIPTION
Some servers use the `.well-known` endpoint to refer to their homeserver address. The `matrix.org` server is not located at [matrix.org](https://matrix.org), for example.

Some homeservers have that, however. In such a case, the Elm SDK still tries to find the `.well-known` endpoint, and rejects the connection if the endpoint is not found. Instead, when the `.well-known` endpoint is not found, this pull request lets the Elm SDK use the server name as the server address.