### PR TITLE
Add full Matrix API from alpha

### DIFF
--- a/docs/before-merge.md
+++ b/docs/before-merge.md
@@ -9,6 +9,7 @@ If you wish to merge your branch to the `develop` branch, make sure to follow th
 - [ ] Run `elm-format` to ensure the correct formatting of the Elm files.
 - [ ] Use `elm-doc-preview` to verify whether the documentation is up to standards.
 - [ ] Run `elm-test` to verify that all tests run successfully.
+- [ ] Make sure that `docs/supported.md` is up to standards.
 
 ## The `develop` branch to `main`
 
@@ -19,6 +20,7 @@ Before that is being done, however, the following tasks should be done:
 - [ ] Run `elm-format` to ensure the correct formatting of the Elm files.
 - [ ] Use `elm-doc-preview` to verify whether the documentation is up to standards.
 - [ ] Run `elm-test --fuzz 1000` to verify that all tests run successfully.
+- [ ] Make sure that `docs/supported.md` is up to standards.
 - [ ] Remove exposed modules from `elm.json` that do not need to be exposed modules in the release.
 - [ ] Run `elm bump` to update the library's version number
 - [ ] Update the version name in the [default values config file](../src/Internal/Config/Default.elm).

--- a/docs/supported.md
+++ b/docs/supported.md
@@ -11,5 +11,29 @@ homeserver, or that it may be better to not rely on a specific feature.
 
 ---
 
-Considering that the current version does not support interaction with a
-homeserver, no functionality is supported at any spec version.
+The following table describes which versions are supported by which endpoint.
+The table assumes an order. For the Matrix spec, spec versions are usually
+ordered as following:
+
+(oldest) `r0.0.0`, `r0.0.1`, `r0.1.0`, `r0.2.0`, `r0.3.0`, `r0.4.0`, `r0.5.0`,
+`r0.6.0`, `r0.6.1`, `v1.1`, `v1.2`, `v1.3`, `v1.4`, `v1.5`, `v1.6`, `v1.7`,
+`v1.8`, `v1.9`, `v1.10`, `v1.11`, `v1.12` (newer)
+
+| Elm SDK function        | Spec versions    | Notes |
+| ----------------------- | ---------------- | ----- |
+| Matrix.leave                 | all              |       |
+| Matrix.sendMessageEvent      | all              |       |
+| Matrix.setAccountData        | all              |       |
+| Matrix.sync             | v1.1 and newer   | The `/sync` endpoint is very complex and hence tedious to implement. For this reason, I have not had the time to waste on building support. |
+| Matrix.whoAmI           | r0.3.0 and newer | This endpoint did not exist before that version. |
+| Matrix.Event.redact          | all              |       |
+| Matrix.Invite.accept         | all              |       |
+| Matrix.Invite.reject         | all              |       |
+| Matrix.Room.ban              | all              |       |
+| Matrix.Room.invite           | all              |       |
+| Matrix.Room.kick             | all              | The `/kick` endpoint was added in `r0.1.0`. If a server only supports older versions than that, then the action is taken by sending a custom membership state event. |
+| Matrix.Room.leave            | all              |       |
+| Matrix.Room.redact           | all              |       |
+| Matrix.Room.sendMessageEvent | all              |       |
+| Matrix.Room.sendStateEvent   | all              |       |
+| Matrix.Room.setAccountData   | all              |       |

--- a/docs/supported.md
+++ b/docs/supported.md
@@ -19,19 +19,19 @@ ordered as following:
 `r0.6.0`, `r0.6.1`, `v1.1`, `v1.2`, `v1.3`, `v1.4`, `v1.5`, `v1.6`, `v1.7`,
 `v1.8`, `v1.9`, `v1.10`, `v1.11`, `v1.12` (newer)
 
-| Elm SDK function        | Spec versions    | Notes |
-| ----------------------- | ---------------- | ----- |
+| Elm SDK function             | Spec versions    | Notes |
+| ---------------------------- | ---------------- | ----- |
 | Matrix.leave                 | all              |       |
 | Matrix.sendMessageEvent      | all              |       |
 | Matrix.setAccountData        | all              |       |
-| Matrix.sync             | v1.1 and newer   | The `/sync` endpoint is very complex and hence tedious to implement. For this reason, I have not had the time to waste on building support. |
-| Matrix.whoAmI           | r0.3.0 and newer | This endpoint did not exist before that version. |
+| Matrix.sync                  | v1.1 and newer   | The `/sync` endpoint is very complex and hence tedious to implement. For this reason, the legacy versions have not yet received sync support. |
+| Matrix.whoAmI                | r0.3.0 and newer | This endpoint did not exist before version `r0.3.0`. |
 | Matrix.Event.redact          | all              |       |
 | Matrix.Invite.accept         | all              |       |
 | Matrix.Invite.reject         | all              |       |
 | Matrix.Room.ban              | all              |       |
 | Matrix.Room.invite           | all              |       |
-| Matrix.Room.kick             | all              | The `/kick` endpoint was added in `r0.1.0`. If a server only supports older versions than that, then the action is taken by sending a custom membership state event. |
+| Matrix.Room.kick             | all              | The `/kick` endpoint was added in `r0.1.0`. On older servers, the Elm SDK sends a custom membership state event. |
 | Matrix.Room.leave            | all              |       |
 | Matrix.Room.redact           | all              |       |
 | Matrix.Room.sendMessageEvent | all              |       |

--- a/elm.json
+++ b/elm.json
@@ -7,6 +7,7 @@
     "exposed-modules": [
         "Matrix",
         "Matrix.Event",
+        "Matrix.Invite",
         "Matrix.Room",
         "Matrix.Settings",
         "Matrix.User"

--- a/src/Internal/Api/BanUser/Api.elm
+++ b/src/Internal/Api/BanUser/Api.elm
@@ -13,13 +13,10 @@ This module helps to ban users from a room.
 
 import Internal.Api.Api as A
 import Internal.Api.Request as R
-import Internal.Config.Log exposing (log)
-import Internal.Config.Text as Text
 import Internal.Tools.Json as Json
 import Internal.Values.Envelope as E
 import Internal.Values.Room as R
 import Internal.Values.User as User exposing (User)
-import Internal.Values.Vault as V
 
 
 banUser : BanUserInput -> A.TaskChain (Phantom a) (Phantom a)

--- a/src/Internal/Api/JoinRoomById/Api.elm
+++ b/src/Internal/Api/JoinRoomById/Api.elm
@@ -1,0 +1,124 @@
+module Internal.Api.JoinRoomById.Api exposing (..)
+
+{-| This module allows you to join a room by its id.
+-}
+
+import Internal.Api.Api as A
+import Internal.Api.Request as R
+import Internal.Tools.Json as Json
+import Internal.Values.Envelope as E
+
+
+joinRoomById : JoinRoomByIdInput -> A.TaskChain (Phantom a) (Phantom a)
+joinRoomById =
+    A.startWithVersion "r0.0.0" joinRoomByIdV1
+        |> A.sameForVersion "r0.0.1"
+        |> A.sameForVersion "r0.1.0"
+        |> A.sameForVersion "r0.2.0"
+        |> A.sameForVersion "r0.3.0"
+        |> A.forVersion "r0.4.0" joinRoomByIdV2
+        |> A.sameForVersion "r0.5.0"
+        |> A.sameForVersion "r0.6.0"
+        |> A.sameForVersion "r0.6.1"
+        |> A.forVersion "v1.1" joinRoomByIdV3
+        |> A.sameForVersion "v1.2"
+        |> A.sameForVersion "v1.3"
+        |> A.sameForVersion "v1.4"
+        |> A.sameForVersion "v1.5"
+        |> A.sameForVersion "v1.6"
+        |> A.sameForVersion "v1.7"
+        |> A.sameForVersion "v1.8"
+        |> A.sameForVersion "v1.9"
+        |> A.sameForVersion "v1.10"
+        |> A.sameForVersion "v1.11"
+        |> A.sameForVersion "v1.12"
+        |> A.versionChain
+
+
+{-| Context needed for setting global account data.
+-}
+type alias Phantom a =
+    { a | accessToken : (), baseUrl : (), versions : () }
+
+
+type alias PhantomV1 a =
+    { a | accessToken : (), baseUrl : () }
+
+
+type alias JoinRoomByIdInput =
+    { reason : Maybe String, roomId : String }
+
+
+type alias JoinRoomByIdInputV1 a =
+    { a | roomId : String }
+
+
+type alias JoinRoomByIdInputV2 a =
+    { a | reason : Maybe String, roomId : String }
+
+
+type alias JoinRoomByIdOutputV1 =
+    { roomId : String }
+
+
+joinRoomByIdV1 : JoinRoomByIdInputV1 i -> A.TaskChain (PhantomV1 a) (PhantomV1 a)
+joinRoomByIdV1 { roomId } =
+    A.request
+        { attributes = [ R.accessToken, R.onStatusCode 403 "M_FORBIDDEN" ]
+        , coder = coderV1
+        , contextChange = always identity
+        , method = "POST"
+        , path = [ "_matrix", "client", "r0", "rooms", roomId, "join" ]
+        , toUpdate = always ( E.Optional Nothing, [] )
+        }
+
+
+joinRoomByIdV2 : JoinRoomByIdInputV1 i -> A.TaskChain (PhantomV1 a) (PhantomV1 a)
+joinRoomByIdV2 { roomId } =
+    A.request
+        { attributes =
+            [ R.accessToken
+            , R.onStatusCode 403 "M_FORBIDDEN"
+            , R.onStatusCode 429 "M_LIMIT_EXCEEDED"
+            ]
+        , coder = coderV1
+        , contextChange = always identity
+        , method = "POST"
+        , path = [ "_matrix", "client", "r0", "rooms", roomId, "join" ]
+        , toUpdate = always ( E.Optional Nothing, [] )
+        }
+
+
+joinRoomByIdV3 : JoinRoomByIdInputV2 i -> A.TaskChain (PhantomV1 a) (PhantomV1 a)
+joinRoomByIdV3 { reason, roomId } =
+    A.request
+        { attributes =
+            [ R.accessToken
+            , R.bodyOpString "reason" reason
+            , R.onStatusCode 403 "M_FORBIDDEN"
+            , R.onStatusCode 429 "M_LIMIT_EXCEEDED"
+            ]
+        , coder = coderV1
+        , contextChange = always identity
+        , method = "POST"
+        , path = [ "_matrix", "client", "v3", "rooms", roomId, "join" ]
+        , toUpdate = always ( E.Optional Nothing, [] )
+        }
+
+
+coderV1 : Json.Coder JoinRoomByIdOutputV1
+coderV1 =
+    Json.object1
+        { name = "Join Room By Id Output"
+        , description =
+            [ "Response returned by the homeserver to confirm that one has successfully joined a given room."
+            ]
+        , init = JoinRoomByIdOutputV1
+        }
+        (Json.field.required
+            { fieldName = "room_id"
+            , toField = .roomId
+            , description = [ "The joined room ID." ]
+            , coder = Json.string
+            }
+        )

--- a/src/Internal/Api/KickUser/Api.elm
+++ b/src/Internal/Api/KickUser/Api.elm
@@ -19,7 +19,6 @@ import Internal.Tools.Json as Json
 import Internal.Values.Envelope as E
 import Internal.Values.Room as R
 import Internal.Values.User as User exposing (User)
-import Internal.Values.Vault as V
 
 
 kickUser : KickUserInput -> A.TaskChain (Phantom a) (Phantom a)

--- a/src/Internal/Api/Leave/Api.elm
+++ b/src/Internal/Api/Leave/Api.elm
@@ -1,0 +1,112 @@
+module Internal.Api.Leave.Api exposing (..)
+
+{-|
+
+
+# Leave
+
+This module allows the user to leave a room.
+
+-}
+
+import Internal.Api.Api as A
+import Internal.Api.Request as R
+import Internal.Tools.Json as Json
+import Internal.Values.Envelope as E
+
+
+leave : LeaveInput -> A.TaskChain (Phantom a) (Phantom a)
+leave =
+    A.startWithVersion "r0.0.0" leaveV1
+        |> A.sameForVersion "r0.0.1"
+        |> A.sameForVersion "r0.1.0"
+        |> A.sameForVersion "r0.2.0"
+        |> A.sameForVersion "r0.3.0"
+        |> A.forVersion "r0.4.0" leaveV2
+        |> A.sameForVersion "r0.5.0"
+        |> A.sameForVersion "r0.6.0"
+        |> A.sameForVersion "r0.6.1"
+        |> A.forVersion "v1.1" leaveV3
+        |> A.sameForVersion "v1.2"
+        |> A.sameForVersion "v1.3"
+        |> A.sameForVersion "v1.4"
+        |> A.sameForVersion "v1.5"
+        |> A.sameForVersion "v1.6"
+        |> A.sameForVersion "v1.7"
+        |> A.sameForVersion "v1.8"
+        |> A.sameForVersion "v1.9"
+        |> A.sameForVersion "v1.10"
+        |> A.sameForVersion "v1.11"
+        |> A.sameForVersion "v1.12"
+        |> A.versionChain
+
+
+{-| Context needed for setting global account data.
+-}
+type alias Phantom a =
+    { a | accessToken : (), baseUrl : (), versions : () }
+
+
+type alias PhantomV1 a =
+    { a | accessToken : (), baseUrl : () }
+
+
+type alias LeaveInput =
+    { reason : Maybe String, roomId : String }
+
+
+type alias LeaveInputV1 a =
+    { a | roomId : String }
+
+
+type alias LeaveInputV2 a =
+    { a | reason : Maybe String, roomId : String }
+
+
+type alias LeaveOutputV1 =
+    ()
+
+
+leaveV1 : LeaveInputV1 i -> A.TaskChain (PhantomV1 a) (PhantomV1 a)
+leaveV1 { roomId } =
+    A.request
+        { attributes = [ R.accessToken ]
+        , coder = coderV1
+        , contextChange = always identity
+        , method = "POST"
+        , path = [ "_matrix", "client", "r0", "rooms", roomId, "leave" ]
+        , toUpdate = always ( E.Optional Nothing, [] )
+        }
+
+
+leaveV2 : LeaveInputV1 i -> A.TaskChain (PhantomV1 a) (PhantomV1 a)
+leaveV2 { roomId } =
+    A.request
+        { attributes = [ R.accessToken, R.onStatusCode 429 "M_LIMIT_EXCEEDED" ]
+        , coder = coderV1
+        , contextChange = always identity
+        , method = "POST"
+        , path = [ "_matrix", "client", "r0", "rooms", roomId, "leave" ]
+        , toUpdate = always ( E.Optional Nothing, [] )
+        }
+
+
+leaveV3 : LeaveInputV2 i -> A.TaskChain (PhantomV1 a) (PhantomV1 a)
+leaveV3 { reason, roomId } =
+    A.request
+        { attributes =
+            [ R.accessToken
+            , R.bodyOpString "reason" reason
+            , R.onStatusCode 429 "M_LIMIT_EXCEEDED"
+            ]
+        , coder = coderV1
+        , contextChange = always identity
+        , method = "POST"
+        , path = [ "_matrix", "client", "v3", "rooms", roomId, "leave" ]
+        , toUpdate = always ( E.Optional Nothing, [] )
+        }
+
+
+coderV1 : Json.Coder LeaveOutputV1
+coderV1 =
+    Json.unit

--- a/src/Internal/Api/LoginWithUsernameAndPassword/Api.elm
+++ b/src/Internal/Api/LoginWithUsernameAndPassword/Api.elm
@@ -19,7 +19,6 @@ import Internal.Tools.Json as Json
 import Internal.Values.Context as Context
 import Internal.Values.Envelope as E
 import Internal.Values.User as User exposing (User)
-import Internal.Values.Vault as V
 import Json.Encode as E
 
 

--- a/src/Internal/Api/Main.elm
+++ b/src/Internal/Api/Main.elm
@@ -1,6 +1,6 @@
 module Internal.Api.Main exposing
     ( Msg
-    , banUser, inviteUser, kickUser, sendMessageEvent, sendStateEvent, setAccountData, setRoomAccountData, sync
+    , banUser, inviteUser, kickUser, sendMessageEvent, sendStateEvent, setAccountData, setRoomAccountData, sync, whoAmI
     )
 
 {-|
@@ -18,7 +18,7 @@ This module is used as reference for getting
 
 ## Actions
 
-@docs banUser, inviteUser, kickUser, sendMessageEvent, sendStateEvent, setAccountData, setRoomAccountData, sync
+@docs banUser, inviteUser, kickUser, sendMessageEvent, sendStateEvent, setAccountData, setRoomAccountData, sync, whoAmI
 
 -}
 
@@ -233,3 +233,12 @@ sync env data =
             }
         )
         (Context.apiFormat env.context)
+
+{-| Reveal personal information about the account to the user.
+-}
+whoAmI :
+    E.Envelope a
+    -> { toMsg : Msg -> msg }
+    -> Cmd msg
+whoAmI env data =
+    ITask.run data.toMsg (ITask.whoAmI) (Context.apiFormat env.context)

--- a/src/Internal/Api/Main.elm
+++ b/src/Internal/Api/Main.elm
@@ -259,6 +259,7 @@ sync env data =
         )
         (Context.apiFormat env.context)
 
+
 {-| Reveal personal information about the account to the user.
 -}
 whoAmI :
@@ -266,4 +267,4 @@ whoAmI :
     -> { toMsg : Msg -> msg }
     -> Cmd msg
 whoAmI env data =
-    ITask.run data.toMsg (ITask.whoAmI) (Context.apiFormat env.context)
+    ITask.run data.toMsg ITask.whoAmI (Context.apiFormat env.context)

--- a/src/Internal/Api/Main.elm
+++ b/src/Internal/Api/Main.elm
@@ -1,6 +1,6 @@
 module Internal.Api.Main exposing
     ( Msg
-    , banUser, inviteUser, kickUser, leave, redact, sendMessageEvent, sendStateEvent, setAccountData, setRoomAccountData, sync, whoAmI
+    , banUser, inviteUser, join, kickUser, leave, redact, sendMessageEvent, sendStateEvent, setAccountData, setRoomAccountData, sync, whoAmI
     )
 
 {-|
@@ -18,7 +18,7 @@ This module is used as reference for getting
 
 ## Actions
 
-@docs banUser, inviteUser, kickUser, leave, redact, sendMessageEvent, sendStateEvent, setAccountData, setRoomAccountData, sync, whoAmI
+@docs banUser, inviteUser, join, kickUser, leave, redact, sendMessageEvent, sendStateEvent, setAccountData, setRoomAccountData, sync, whoAmI
 
 -}
 
@@ -76,6 +76,27 @@ inviteUser env data =
             { reason = data.reason
             , roomId = data.roomId
             , user = data.user
+            }
+        )
+        (Context.apiFormat env.context)
+
+
+{-| Join a room by its room id.
+-}
+join :
+    E.Envelope a
+    ->
+        { reason : Maybe String
+        , roomId : String
+        , toMsg : Msg -> msg
+        }
+    -> Cmd msg
+join env data =
+    ITask.run
+        data.toMsg
+        (ITask.join
+            { reason = data.reason
+            , roomId = data.roomId
             }
         )
         (Context.apiFormat env.context)

--- a/src/Internal/Api/Main.elm
+++ b/src/Internal/Api/Main.elm
@@ -27,7 +27,6 @@ import Internal.Tools.Json as Json
 import Internal.Values.Context as Context
 import Internal.Values.Envelope as E
 import Internal.Values.User as User exposing (User)
-import Internal.Values.Vault as V
 
 
 {-| Update message type that is being returned.

--- a/src/Internal/Api/Main.elm
+++ b/src/Internal/Api/Main.elm
@@ -1,6 +1,6 @@
 module Internal.Api.Main exposing
     ( Msg
-    , banUser, inviteUser, kickUser, sendMessageEvent, sendStateEvent, setAccountData, setRoomAccountData, sync, whoAmI
+    , banUser, inviteUser, kickUser, redact, sendMessageEvent, sendStateEvent, setAccountData, setRoomAccountData, sync, whoAmI
     )
 
 {-|
@@ -18,7 +18,7 @@ This module is used as reference for getting
 
 ## Actions
 
-@docs banUser, inviteUser, kickUser, sendMessageEvent, sendStateEvent, setAccountData, setRoomAccountData, sync, whoAmI
+@docs banUser, inviteUser, kickUser, redact, sendMessageEvent, sendStateEvent, setAccountData, setRoomAccountData, sync, whoAmI
 
 -}
 
@@ -101,6 +101,31 @@ kickUser env data =
             , reason = data.reason
             , roomId = data.roomId
             , user = data.user
+            }
+        )
+        (Context.apiFormat env.context)
+
+
+{-| Redact an event.
+-}
+redact :
+    E.Envelope a
+    ->
+        { eventId : String
+        , reason : Maybe String
+        , roomId : String
+        , toMsg : Msg -> msg
+        , transactionId : String
+        }
+    -> Cmd msg
+redact env data =
+    ITask.run
+        data.toMsg
+        (ITask.redact
+            { eventId = data.eventId
+            , reason = data.reason
+            , roomId = data.roomId
+            , transactionId = data.transactionId
             }
         )
         (Context.apiFormat env.context)

--- a/src/Internal/Api/Main.elm
+++ b/src/Internal/Api/Main.elm
@@ -1,6 +1,6 @@
 module Internal.Api.Main exposing
     ( Msg
-    , banUser, inviteUser, kickUser, redact, sendMessageEvent, sendStateEvent, setAccountData, setRoomAccountData, sync, whoAmI
+    , banUser, inviteUser, kickUser, leave, redact, sendMessageEvent, sendStateEvent, setAccountData, setRoomAccountData, sync, whoAmI
     )
 
 {-|
@@ -18,7 +18,7 @@ This module is used as reference for getting
 
 ## Actions
 
-@docs banUser, inviteUser, kickUser, redact, sendMessageEvent, sendStateEvent, setAccountData, setRoomAccountData, sync, whoAmI
+@docs banUser, inviteUser, kickUser, leave, redact, sendMessageEvent, sendStateEvent, setAccountData, setRoomAccountData, sync, whoAmI
 
 -}
 
@@ -103,6 +103,23 @@ kickUser env data =
             , user = data.user
             }
         )
+        (Context.apiFormat env.context)
+
+
+{-| Leave a room.
+-}
+leave :
+    E.Envelope a
+    ->
+        { reason : Maybe String
+        , roomId : String
+        , toMsg : Msg -> msg
+        }
+    -> Cmd msg
+leave env data =
+    ITask.run
+        data.toMsg
+        (ITask.leave { reason = data.reason, roomId = data.roomId })
         (Context.apiFormat env.context)
 
 

--- a/src/Internal/Api/Redact/Api.elm
+++ b/src/Internal/Api/Redact/Api.elm
@@ -1,0 +1,108 @@
+module Internal.Api.Redact.Api exposing (..)
+
+{-| # Redact
+
+This module allows the user to redact an event from a room.
+
+-}
+
+import Internal.Api.Api as A
+import Internal.Api.Request as R
+import Internal.Tools.Json as Json
+import Internal.Values.Envelope as E
+
+redact : RedactInput -> A.TaskChain (Phantom a) (Phantom a)
+redact =
+    A.startWithVersion "r0.0.0" redactV1
+        |> A.sameForVersion "r0.0.1"
+        |> A.forVersion "r0.1.0" redactV2
+        |> A.sameForVersion "r0.2.0"
+        |> A.sameForVersion "r0.3.0"
+        |> A.sameForVersion "r0.4.0"
+        |> A.sameForVersion "r0.5.0"
+        |> A.sameForVersion "r0.6.0"
+        |> A.sameForVersion "r0.6.1"
+        |> A.forVersion "v1.1" redactV3
+        |> A.sameForVersion "v1.2"
+        |> A.sameForVersion "v1.3"
+        |> A.sameForVersion "v1.4"
+        |> A.sameForVersion "v1.5"
+        |> A.sameForVersion "v1.6"
+        |> A.sameForVersion "v1.7"
+        |> A.sameForVersion "v1.8"
+        |> A.sameForVersion "v1.9"
+        |> A.sameForVersion "v1.10"
+        |> A.sameForVersion "v1.11"
+        |> A.sameForVersion "v1.12"
+        |> A.versionChain
+
+{-| Context needed for setting global account data.
+-}
+type alias Phantom a =
+    { a | accessToken : (), baseUrl : (), versions : () }
+
+
+type alias PhantomV1 a =
+    { a | accessToken : (), baseUrl : () }
+
+type alias RedactInput =
+    { eventId : String
+    , reason : Maybe String
+    , roomId : String
+    , transactionId : String
+    }
+
+type alias RedactInputV1 a =
+    { a | eventId : String, reason : Maybe String, roomId : String, transactionId : String }
+
+type alias RedactOutputV1 = { eventId : Maybe String }
+
+redactV1 : RedactInputV1 i -> A.TaskChain (Phantom a) (Phantom a)
+redactV1 { eventId, reason, roomId, transactionId } =
+    A.request
+        { attributes = [ R.accessToken, R.bodyOpString "reason" reason ]
+        , coder = coderV1
+        , contextChange = always identity
+        , method = "PUT"
+        , path = [ "_matrix", "client", "api", "r0", "rooms", roomId, "redact", eventId, transactionId ]
+        , toUpdate = always ( E.Optional Nothing, [] )
+        }
+
+redactV2 : RedactInputV1 i -> A.TaskChain (Phantom a) (Phantom a)
+redactV2 { eventId, reason, roomId, transactionId } =
+    A.request
+        { attributes = [ R.accessToken, R.bodyOpString "reason" reason ]
+        , coder = coderV1
+        , contextChange = always identity
+        , method = "PUT"
+        , path = [ "_matrix", "client", "r0", "rooms", roomId, "redact", eventId, transactionId ]
+        , toUpdate = always ( E.Optional Nothing, [] )
+        }
+
+redactV3 : RedactInputV1 i -> A.TaskChain (Phantom a) (Phantom a)
+redactV3 { eventId, reason, roomId, transactionId } =
+    A.request
+        { attributes = [ R.accessToken, R.bodyOpString "reason" reason ]
+        , coder = coderV1
+        , contextChange = always identity
+        , method = "PUT"
+        , path = [ "_matrix", "client", "v3", "rooms", roomId, "redact", eventId, transactionId ]
+        , toUpdate = always ( E.Optional Nothing, [] )
+        }
+
+coderV1 : Json.Coder RedactOutputV1
+coderV1 =
+    Json.object1
+        { name = "Redact Output"
+        , description =
+            [ "Event ID of the redaction event"
+            ]
+        , init = RedactOutputV1
+        }
+        ( Json.field.optional.value
+            { fieldName = "event_id"
+            , toField = .eventId
+            , description = [ "Event ID of the redaction event" ]
+            , coder = Json.string
+            }
+        )

--- a/src/Internal/Api/Redact/Api.elm
+++ b/src/Internal/Api/Redact/Api.elm
@@ -1,6 +1,9 @@
 module Internal.Api.Redact.Api exposing (..)
 
-{-| # Redact
+{-|
+
+
+# Redact
 
 This module allows the user to redact an event from a room.
 
@@ -10,6 +13,7 @@ import Internal.Api.Api as A
 import Internal.Api.Request as R
 import Internal.Tools.Json as Json
 import Internal.Values.Envelope as E
+
 
 redact : RedactInput -> A.TaskChain (Phantom a) (Phantom a)
 redact =
@@ -36,6 +40,7 @@ redact =
         |> A.sameForVersion "v1.12"
         |> A.versionChain
 
+
 {-| Context needed for setting global account data.
 -}
 type alias Phantom a =
@@ -45,6 +50,7 @@ type alias Phantom a =
 type alias PhantomV1 a =
     { a | accessToken : (), baseUrl : () }
 
+
 type alias RedactInput =
     { eventId : String
     , reason : Maybe String
@@ -52,10 +58,14 @@ type alias RedactInput =
     , transactionId : String
     }
 
+
 type alias RedactInputV1 a =
     { a | eventId : String, reason : Maybe String, roomId : String, transactionId : String }
 
-type alias RedactOutputV1 = { eventId : Maybe String }
+
+type alias RedactOutputV1 =
+    { eventId : Maybe String }
+
 
 redactV1 : RedactInputV1 i -> A.TaskChain (Phantom a) (Phantom a)
 redactV1 { eventId, reason, roomId, transactionId } =
@@ -68,6 +78,7 @@ redactV1 { eventId, reason, roomId, transactionId } =
         , toUpdate = always ( E.Optional Nothing, [] )
         }
 
+
 redactV2 : RedactInputV1 i -> A.TaskChain (Phantom a) (Phantom a)
 redactV2 { eventId, reason, roomId, transactionId } =
     A.request
@@ -78,6 +89,7 @@ redactV2 { eventId, reason, roomId, transactionId } =
         , path = [ "_matrix", "client", "r0", "rooms", roomId, "redact", eventId, transactionId ]
         , toUpdate = always ( E.Optional Nothing, [] )
         }
+
 
 redactV3 : RedactInputV1 i -> A.TaskChain (Phantom a) (Phantom a)
 redactV3 { eventId, reason, roomId, transactionId } =
@@ -90,6 +102,7 @@ redactV3 { eventId, reason, roomId, transactionId } =
         , toUpdate = always ( E.Optional Nothing, [] )
         }
 
+
 coderV1 : Json.Coder RedactOutputV1
 coderV1 =
     Json.object1
@@ -99,7 +112,7 @@ coderV1 =
             ]
         , init = RedactOutputV1
         }
-        ( Json.field.optional.value
+        (Json.field.optional.value
             { fieldName = "event_id"
             , toField = .eventId
             , description = [ "Event ID of the redaction event" ]

--- a/src/Internal/Api/SetAccountData/Api.elm
+++ b/src/Internal/Api/SetAccountData/Api.elm
@@ -13,8 +13,6 @@ This module allows the developer to set global account data.
 
 import Internal.Api.Api as A
 import Internal.Api.Request as R
-import Internal.Config.Log exposing (log)
-import Internal.Config.Text as Text
 import Internal.Tools.Json as Json
 import Internal.Values.Envelope as E
 import Internal.Values.Room as R

--- a/src/Internal/Api/SetRoomAccountData/Api.elm
+++ b/src/Internal/Api/SetRoomAccountData/Api.elm
@@ -13,8 +13,6 @@ This module allows the developer to set account data to a Matrix room.
 
 import Internal.Api.Api as A
 import Internal.Api.Request as R
-import Internal.Config.Log exposing (log)
-import Internal.Config.Text as Text
 import Internal.Tools.Json as Json
 import Internal.Values.Envelope as E
 import Internal.Values.Room as R

--- a/src/Internal/Api/Sync/V2.elm
+++ b/src/Internal/Api/Sync/V2.elm
@@ -612,6 +612,14 @@ updateSyncResponse { filter, since } response =
 updateRooms : { filter : Filter, nextBatch : String, since : Maybe String } -> Rooms -> ( V.VaultUpdate, List Log )
 updateRooms { filter, nextBatch, since } rooms =
     let
+        ( inviteUpdate, inviteLogs ) =
+            rooms.invite
+                |> Maybe.withDefault Dict.empty
+                |> Dict.toList
+                |> List.map (\( roomId, invite ) -> updateInvitedRoom roomId invite)
+                |> List.unzip
+                |> Tuple.mapBoth V.More List.concat
+
         ( roomUpdate, roomLogs ) =
             rooms.join
                 |> Maybe.withDefault Dict.empty
@@ -641,15 +649,22 @@ updateRooms { filter, nextBatch, since } rooms =
             |> List.map V.CreateRoomIfNotExists
             |> V.More
 
+        -- Update invites
+        , inviteUpdate
+
         -- Update rooms
         , roomUpdate
 
-        -- TODO: Add invited rooms
         -- TODO: Add knocked rooms
         -- TODO: Add left rooms
         ]
-    , roomLogs
+    , List.append inviteLogs roomLogs
     )
+
+
+updateInvitedRoom : String -> InvitedRoom -> ( V.VaultUpdate, List Log )
+updateInvitedRoom =
+    PV.updateInvitedRoom
 
 
 updateJoinedRoom : { filter : Filter, nextBatch : String, roomId : String, since : Maybe String } -> JoinedRoom -> ( R.RoomUpdate, List Log )

--- a/src/Internal/Api/Task.elm
+++ b/src/Internal/Api/Task.elm
@@ -1,6 +1,6 @@
 module Internal.Api.Task exposing
     ( Task, run, Backpack
-    , banUser, inviteUser, kickUser, sendMessageEvent, sendStateEvent, setAccountData, setRoomAccountData, sync, whoAmI
+    , banUser, inviteUser, kickUser, redact, sendMessageEvent, sendStateEvent, setAccountData, setRoomAccountData, sync, whoAmI
     )
 
 {-|
@@ -23,7 +23,7 @@ up-to-date.
 
 ## Tasks
 
-@docs banUser, inviteUser, kickUser, sendMessageEvent, sendStateEvent, setAccountData, setRoomAccountData, sync, whoAmI
+@docs banUser, inviteUser, kickUser, redact, sendMessageEvent, sendStateEvent, setAccountData, setRoomAccountData, sync, whoAmI
 
 -}
 
@@ -34,6 +34,7 @@ import Internal.Api.InviteUser.Api
 import Internal.Api.KickUser.Api
 import Internal.Api.LoginWithUsernameAndPassword.Api
 import Internal.Api.Now.Api
+import Internal.Api.Redact.Api
 import Internal.Api.Request as Request
 import Internal.Api.SendMessageEvent.Api
 import Internal.Api.SendStateEvent.Api
@@ -263,6 +264,15 @@ makeVBA =
     makeVB
         |> C.andThen getNow
         |> C.andThen getAccessToken
+
+
+{-| Redact an event from a room.
+-}
+redact : { eventId : String, reason : Maybe String, roomId : String, transactionId : String } -> Task
+redact input =
+    makeVBA
+        |> C.andThen (Internal.Api.Redact.Api.redact input)
+        |> finishTask
 
 
 {-| Send a message event to a room.

--- a/src/Internal/Api/Task.elm
+++ b/src/Internal/Api/Task.elm
@@ -1,6 +1,6 @@
 module Internal.Api.Task exposing
     ( Task, run, Backpack
-    , banUser, inviteUser, kickUser, leave, redact, sendMessageEvent, sendStateEvent, setAccountData, setRoomAccountData, sync, whoAmI
+    , banUser, inviteUser, join, kickUser, leave, redact, sendMessageEvent, sendStateEvent, setAccountData, setRoomAccountData, sync, whoAmI
     )
 
 {-|
@@ -23,7 +23,7 @@ up-to-date.
 
 ## Tasks
 
-@docs banUser, inviteUser, kickUser, leave, redact, sendMessageEvent, sendStateEvent, setAccountData, setRoomAccountData, sync, whoAmI
+@docs banUser, inviteUser, join, kickUser, leave, redact, sendMessageEvent, sendStateEvent, setAccountData, setRoomAccountData, sync, whoAmI
 
 -}
 
@@ -31,6 +31,7 @@ import Internal.Api.BanUser.Api
 import Internal.Api.BaseUrl.Api
 import Internal.Api.Chain as C
 import Internal.Api.InviteUser.Api
+import Internal.Api.JoinRoomById.Api
 import Internal.Api.KickUser.Api
 import Internal.Api.Leave.Api
 import Internal.Api.LoginWithUsernameAndPassword.Api
@@ -229,6 +230,15 @@ inviteUser : { reason : Maybe String, roomId : String, user : User } -> Task
 inviteUser input =
     makeVBA
         |> C.andThen (Internal.Api.InviteUser.Api.inviteUser input)
+        |> finishTask
+
+
+{-| Join a room.
+-}
+join : { reason : Maybe String, roomId : String } -> Task
+join input =
+    makeVBA
+        |> C.andThen (Internal.Api.JoinRoomById.Api.joinRoomById input)
         |> finishTask
 
 

--- a/src/Internal/Api/Task.elm
+++ b/src/Internal/Api/Task.elm
@@ -1,6 +1,6 @@
 module Internal.Api.Task exposing
     ( Task, run, Backpack
-    , banUser, inviteUser, kickUser, sendMessageEvent, sendStateEvent, setAccountData, setRoomAccountData, sync
+    , banUser, inviteUser, kickUser, sendMessageEvent, sendStateEvent, setAccountData, setRoomAccountData, sync, whoAmI
     )
 
 {-|
@@ -23,7 +23,7 @@ up-to-date.
 
 ## Tasks
 
-@docs banUser, inviteUser, kickUser, sendMessageEvent, sendStateEvent, setAccountData, setRoomAccountData, sync
+@docs banUser, inviteUser, kickUser, sendMessageEvent, sendStateEvent, setAccountData, setRoomAccountData, sync, whoAmI
 
 -}
 
@@ -41,6 +41,7 @@ import Internal.Api.SetAccountData.Api
 import Internal.Api.SetRoomAccountData.Api
 import Internal.Api.Sync.Api
 import Internal.Api.Versions.Api
+import Internal.Api.WhoAmI.Api
 import Internal.Config.Log exposing (Log, log)
 import Internal.Config.Text as Text
 import Internal.Tools.Json as Json
@@ -306,6 +307,15 @@ sync : { fullState : Maybe Bool, presence : Maybe String, since : Maybe String, 
 sync input =
     makeVBA
         |> C.andThen (Internal.Api.Sync.Api.sync input)
+        |> finishTask
+
+
+{-| Reveal personal information about the account to the user.
+-}
+whoAmI : Task
+whoAmI =
+    makeVBA
+        |> C.andThen (Internal.Api.WhoAmI.Api.whoAmI {})
         |> finishTask
 
 

--- a/src/Internal/Api/Task.elm
+++ b/src/Internal/Api/Task.elm
@@ -1,6 +1,6 @@
 module Internal.Api.Task exposing
     ( Task, run, Backpack
-    , banUser, inviteUser, kickUser, redact, sendMessageEvent, sendStateEvent, setAccountData, setRoomAccountData, sync, whoAmI
+    , banUser, inviteUser, kickUser, leave, redact, sendMessageEvent, sendStateEvent, setAccountData, setRoomAccountData, sync, whoAmI
     )
 
 {-|
@@ -23,7 +23,7 @@ up-to-date.
 
 ## Tasks
 
-@docs banUser, inviteUser, kickUser, redact, sendMessageEvent, sendStateEvent, setAccountData, setRoomAccountData, sync, whoAmI
+@docs banUser, inviteUser, kickUser, leave, redact, sendMessageEvent, sendStateEvent, setAccountData, setRoomAccountData, sync, whoAmI
 
 -}
 
@@ -32,6 +32,7 @@ import Internal.Api.BaseUrl.Api
 import Internal.Api.Chain as C
 import Internal.Api.InviteUser.Api
 import Internal.Api.KickUser.Api
+import Internal.Api.Leave.Api
 import Internal.Api.LoginWithUsernameAndPassword.Api
 import Internal.Api.Now.Api
 import Internal.Api.Redact.Api
@@ -244,6 +245,19 @@ kickUser :
 kickUser input =
     makeVBA
         |> C.andThen (Internal.Api.KickUser.Api.kickUser input)
+        |> finishTask
+
+
+{-| Leave a room.
+-}
+leave :
+    { reason : Maybe String
+    , roomId : String
+    }
+    -> Task
+leave input =
+    makeVBA
+        |> C.andThen (Internal.Api.Leave.Api.leave input)
         |> finishTask
 
 

--- a/src/Internal/Api/WhoAmI/Api.elm
+++ b/src/Internal/Api/WhoAmI/Api.elm
@@ -1,0 +1,203 @@
+module Internal.Api.WhoAmI.Api exposing (..)
+
+{-| # Who Am I?
+
+This module allows the Elm SDK user to view who the vault represents.
+
+-}
+
+import Internal.Api.Api as A
+import Internal.Api.Request as R
+import Internal.Tools.Json as Json
+import Internal.Values.Envelope as E
+import Internal.Values.Room as R
+import Internal.Values.User as User exposing (User)
+
+whoAmI : WhoAmIInput -> A.TaskChain (Phantom a) (Phantom a)
+whoAmI =
+    A.startWithVersion "r0.3.0" whoAmIV1
+        |> A.forVersion "r0.4.0" whoAmIV2
+        |> A.sameForVersion "r0.5.0"
+        |> A.sameForVersion "r0.6.0"
+        |> A.sameForVersion "r0.6.1"
+        |> A.forVersion "v1.1" whoAmIV3
+        |> A.forVersion "v1.2" whoAmIV4
+        |> A.sameForVersion "v1.3"
+        |> A.sameForVersion "v1.4"
+        |> A.sameForVersion "v1.5"
+        |> A.sameForVersion "v1.6"
+        |> A.sameForVersion "v1.7"
+        |> A.sameForVersion "v1.8"
+        |> A.sameForVersion "v1.9"
+        |> A.sameForVersion "v1.10"
+        |> A.sameForVersion "v1.11"
+        |> A.sameForVersion "v1.12"
+        |> A.versionChain
+
+{-| Context needed for setting global account data.
+-}
+type alias Phantom a =
+    { a | accessToken : (), baseUrl : (), versions : () }
+
+
+type alias PhantomV1 a =
+    { a | accessToken : (), baseUrl : () }
+
+type alias WhoAmIInput =
+    {}
+
+type alias WhoAmIInputV1 a = a
+
+type alias WhoAmIOutputV1 = { user : User }
+
+type alias WhoAmIOutputV2 = { deviceId : Maybe String, user : User }
+
+type alias WhoAmIOutputV3 = { deviceId : Maybe String, isGuest : Bool, user : User }
+
+whoAmIV1 : WhoAmIInputV1 i -> A.TaskChain (PhantomV1 a) (PhantomV1 a)
+whoAmIV1 _ =
+    A.request
+        { attributes = [ R.accessToken ]
+        , coder = coderV1
+        , contextChange = always identity
+        , method = "GET"
+        , path = [ "_matrix", "client", "r0", "account", "whoami" ]
+        , toUpdate = (\out -> ( E.SetUser out.user, [] ))
+        }
+
+whoAmIV2 : WhoAmIInputV1 i -> A.TaskChain (PhantomV1 a) (PhantomV1 a)
+whoAmIV2 _ =
+    A.request
+        { attributes =
+            [ R.accessToken
+            , R.onStatusCode 401 "M_UNKNOWN_TOKEN"
+            , R.onStatusCode 403 "M_FORBIDDEN"
+            , R.onStatusCode 429 "M_LIMIT_EXCEEDED"
+            ]
+        , coder = coderV1
+        , contextChange = always identity
+        , method = "GET"
+        , path = [ "_matrix", "client", "r0", "account", "whoami" ]
+        , toUpdate = (\out -> ( E.SetUser out.user, [] ))
+        }
+
+whoAmIV3 : WhoAmIInputV1 i -> A.TaskChain (PhantomV1 a) (PhantomV1 a)
+whoAmIV3 _ =
+    A.request
+        { attributes =
+            [ R.accessToken
+            , R.onStatusCode 401 "M_UNKNOWN_TOKEN"
+            , R.onStatusCode 403 "M_FORBIDDEN"
+            , R.onStatusCode 429 "M_LIMIT_EXCEEDED"
+            ]
+        , coder = coderV2
+        , contextChange = always identity
+        , method = "GET"
+        , path = [ "_matrix", "client", "v3", "account", "whoami" ]
+        , toUpdate =
+            (\out ->
+                ( E.More
+                    [ E.SetUser out.user
+                    , E.Optional (Maybe.map E.SetDeviceId out.deviceId)
+                    ]
+                , []
+                )
+            )
+        }
+
+whoAmIV4 : WhoAmIInputV1 i -> A.TaskChain (PhantomV1 a) (PhantomV1 a)
+whoAmIV4 _ =
+    A.request
+        { attributes =
+            [ R.accessToken
+            , R.onStatusCode 401 "M_UNKNOWN_TOKEN"
+            , R.onStatusCode 403 "M_FORBIDDEN"
+            , R.onStatusCode 429 "M_LIMIT_EXCEEDED"
+            ]
+        , coder = coderV3
+        , contextChange = always identity
+        , method = "GET"
+        , path = [ "_matrix", "client", "v3", "account", "whoami" ]
+        , toUpdate =
+            (\out ->
+                ( E.More
+                    [ E.SetUser out.user
+                    , E.Optional (Maybe.map E.SetDeviceId out.deviceId)
+                    ]
+                , []
+                )
+            )
+        }
+
+coderV1 : Json.Coder WhoAmIOutputV1
+coderV1 =
+    Json.object1
+        { name = "Who Am I Output"
+        , description =
+            [ "Reveals the identity of the account to the user"
+            ]
+        , init = WhoAmIOutputV1
+        }
+        (Json.field.required
+            { fieldName = "user_id"
+            , toField = .user
+            , description = [ "The user that owns the access token" ]
+            , coder = User.coder
+            }
+        )
+
+coderV2 : Json.Coder WhoAmIOutputV2
+coderV2 =
+    Json.object2
+        { name = "Who Am I Output"
+        , description =
+            [ "Reveals the identity of the account to the user"
+            ]
+        , init = WhoAmIOutputV2
+        }
+        (Json.field.optional.value
+            { fieldName = "device_id"
+            , toField = .deviceId
+            , description = [ "Device ID associated with the access token." ]
+            , coder = Json.string
+            }
+        )
+        (Json.field.required
+            { fieldName = "user_id"
+            , toField = .user
+            , description = [ "The user that owns the access token" ]
+            , coder = User.coder
+            }
+        )
+
+coderV3 : Json.Coder WhoAmIOutputV3
+coderV3 =
+    Json.object3
+        { name = "Who Am I Output"
+        , description =
+            [ "Reveals the identity of the account to the user"
+            ]
+        , init = WhoAmIOutputV3
+        }
+        (Json.field.optional.value
+            { fieldName = "device_id"
+            , toField = .deviceId
+            , description = [ "Device ID associated with the access token." ]
+            , coder = Json.string
+            }
+        )
+        (Json.field.optional.withDefault
+            { fieldName = "is_guest"
+            , toField = .isGuest
+            , description = [ "When true, the user is a guest user." ]
+            , coder = Json.bool
+            , default = ( False, [] )
+            }
+        )
+        (Json.field.required
+            { fieldName = "user_id"
+            , toField = .user
+            , description = [ "The user that owns the access token" ]
+            , coder = User.coder
+            }
+        )

--- a/src/Internal/Api/WhoAmI/Api.elm
+++ b/src/Internal/Api/WhoAmI/Api.elm
@@ -1,6 +1,9 @@
 module Internal.Api.WhoAmI.Api exposing (..)
 
-{-| # Who Am I?
+{-|
+
+
+# Who Am I?
 
 This module allows the Elm SDK user to view who the vault represents.
 
@@ -12,6 +15,7 @@ import Internal.Tools.Json as Json
 import Internal.Values.Envelope as E
 import Internal.Values.Room as R
 import Internal.Values.User as User exposing (User)
+
 
 whoAmI : WhoAmIInput -> A.TaskChain (Phantom a) (Phantom a)
 whoAmI =
@@ -34,6 +38,7 @@ whoAmI =
         |> A.sameForVersion "v1.12"
         |> A.versionChain
 
+
 {-| Context needed for setting global account data.
 -}
 type alias Phantom a =
@@ -43,16 +48,26 @@ type alias Phantom a =
 type alias PhantomV1 a =
     { a | accessToken : (), baseUrl : () }
 
+
 type alias WhoAmIInput =
     {}
 
-type alias WhoAmIInputV1 a = a
 
-type alias WhoAmIOutputV1 = { user : User }
+type alias WhoAmIInputV1 a =
+    a
 
-type alias WhoAmIOutputV2 = { deviceId : Maybe String, user : User }
 
-type alias WhoAmIOutputV3 = { deviceId : Maybe String, isGuest : Bool, user : User }
+type alias WhoAmIOutputV1 =
+    { user : User }
+
+
+type alias WhoAmIOutputV2 =
+    { deviceId : Maybe String, user : User }
+
+
+type alias WhoAmIOutputV3 =
+    { deviceId : Maybe String, isGuest : Bool, user : User }
+
 
 whoAmIV1 : WhoAmIInputV1 i -> A.TaskChain (PhantomV1 a) (PhantomV1 a)
 whoAmIV1 _ =
@@ -62,8 +77,9 @@ whoAmIV1 _ =
         , contextChange = always identity
         , method = "GET"
         , path = [ "_matrix", "client", "r0", "account", "whoami" ]
-        , toUpdate = (\out -> ( E.SetUser out.user, [] ))
+        , toUpdate = \out -> ( E.SetUser out.user, [] )
         }
+
 
 whoAmIV2 : WhoAmIInputV1 i -> A.TaskChain (PhantomV1 a) (PhantomV1 a)
 whoAmIV2 _ =
@@ -78,8 +94,9 @@ whoAmIV2 _ =
         , contextChange = always identity
         , method = "GET"
         , path = [ "_matrix", "client", "r0", "account", "whoami" ]
-        , toUpdate = (\out -> ( E.SetUser out.user, [] ))
+        , toUpdate = \out -> ( E.SetUser out.user, [] )
         }
+
 
 whoAmIV3 : WhoAmIInputV1 i -> A.TaskChain (PhantomV1 a) (PhantomV1 a)
 whoAmIV3 _ =
@@ -95,15 +112,15 @@ whoAmIV3 _ =
         , method = "GET"
         , path = [ "_matrix", "client", "v3", "account", "whoami" ]
         , toUpdate =
-            (\out ->
+            \out ->
                 ( E.More
                     [ E.SetUser out.user
                     , E.Optional (Maybe.map E.SetDeviceId out.deviceId)
                     ]
                 , []
                 )
-            )
         }
+
 
 whoAmIV4 : WhoAmIInputV1 i -> A.TaskChain (PhantomV1 a) (PhantomV1 a)
 whoAmIV4 _ =
@@ -119,15 +136,15 @@ whoAmIV4 _ =
         , method = "GET"
         , path = [ "_matrix", "client", "v3", "account", "whoami" ]
         , toUpdate =
-            (\out ->
+            \out ->
                 ( E.More
                     [ E.SetUser out.user
                     , E.Optional (Maybe.map E.SetDeviceId out.deviceId)
                     ]
                 , []
                 )
-            )
         }
+
 
 coderV1 : Json.Coder WhoAmIOutputV1
 coderV1 =
@@ -145,6 +162,7 @@ coderV1 =
             , coder = User.coder
             }
         )
+
 
 coderV2 : Json.Coder WhoAmIOutputV2
 coderV2 =
@@ -169,6 +187,7 @@ coderV2 =
             , coder = User.coder
             }
         )
+
 
 coderV3 : Json.Coder WhoAmIOutputV3
 coderV3 =

--- a/src/Internal/Config/Text.elm
+++ b/src/Internal/Config/Text.elm
@@ -118,6 +118,8 @@ docs :
     , event : TypeDocs
     , hashdict : TypeDocs
     , ibatch : TypeDocs
+    , invite : TypeDocs
+    , inviteEvent : TypeDocs
     , itoken : TypeDocs
     , mashdict : TypeDocs
     , room : TypeDocs
@@ -167,6 +169,18 @@ docs =
         { name = "IBatch"
         , description =
             [ "The internal batch tracks a patch of events on the Matrix timeline."
+            ]
+        }
+    , invite =
+        { name = "Invite"
+        , description =
+            [ "The Invite type represents an invitation to join a Matrix room."
+            ]
+        }
+    , inviteEvent =
+        { name = "InviteEvent"
+        , description =
+            [ "The InviteEvent type represents a state event that can be previewed of a room that the user has been invited to."
             ]
         }
     , itoken =
@@ -306,6 +320,10 @@ fields :
         { cursor : Desc
         , dict : Desc
         }
+    , invite :
+        { events : Desc
+        , roomId : Desc
+        }
     , itoken :
         { behind : Desc
         , ends : Desc
@@ -350,6 +368,7 @@ fields :
         }
     , vault :
         { accountData : Desc
+        , invites : Desc
         , nextBatch : Desc
         , rooms : Desc
         , user : Desc
@@ -478,6 +497,14 @@ fields =
             [ "Dictionary that contains all values stored in the iddict."
             ]
         }
+    , invite =
+        { events =
+            [ "State events that render a preview of the room that the user is invited to."
+            ]
+        , roomId =
+            [ "Room ID of the room that the invite is to."
+            ]
+        }
     , itoken =
         { behind =
             [ "This token is behind all tokens in this field."
@@ -581,6 +608,9 @@ fields =
     , vault =
         { accountData =
             [ "The account's global private data."
+            ]
+        , invites =
+            [ "Collection of invites that the user has received."
             ]
         , nextBatch =
             [ "The next batch that can be used to sync with the Matrix API."

--- a/src/Internal/Values/Invite.elm
+++ b/src/Internal/Values/Invite.elm
@@ -1,0 +1,127 @@
+module Internal.Values.Invite exposing (..)
+
+{-|
+
+
+# Invite
+
+An invite is an invitation to join a room. This offers the user an opportunity
+to participate in a private room, or helps other users discover a room that
+might be relevant to them.
+
+-}
+
+import FastDict as Dict exposing (Dict)
+import Internal.Config.Text as Text
+import Internal.Tools.Json as Json
+import Internal.Values.User as User exposing (User)
+
+
+type alias Invite =
+    { roomId : String
+    , events : Dict String (Dict String InviteEvent)
+    }
+
+
+type alias InviteEvent =
+    { content : Json.Value
+    , sender : User
+    , stateKey : String
+    , eventType : String
+    }
+
+
+addInviteEvent : InviteEvent -> Invite -> Invite
+addInviteEvent event invite =
+    { invite
+        | events =
+            Dict.update event.eventType
+                (\mdict ->
+                    case mdict of
+                        Just dict ->
+                            Just (Dict.insert event.stateKey event dict)
+
+                        Nothing ->
+                            Just (Dict.singleton event.stateKey event)
+                )
+                invite.events
+    }
+
+
+{-| Define how an invite is encoded in JSON.
+-}
+coder : Json.Coder Invite
+coder =
+    Json.object2
+        { name = Text.docs.invite.name
+        , description = Text.docs.invite.description
+        , init = Invite
+        }
+        (Json.field.required
+            { fieldName = "roomId"
+            , toField = .roomId
+            , description = Text.fields.invite.roomId
+            , coder = Json.string
+            }
+        )
+        (Json.field.optional.withDefault
+            { fieldName = "events"
+            , toField = .events
+            , description = Text.fields.invite.events
+            , coder = Json.fastDict <| Json.fastDict coderEvent
+            , default = ( Dict.empty, [] )
+            }
+        )
+
+
+{-| Define how an InviteEvent is encoded in JSON.
+-}
+coderEvent : Json.Coder InviteEvent
+coderEvent =
+    Json.object4
+        { name = Text.docs.inviteEvent.name
+        , description = Text.docs.inviteEvent.description
+        , init = InviteEvent
+        }
+        (Json.field.required
+            { fieldName = "content"
+            , toField = .content
+            , description = Text.fields.event.content
+            , coder = Json.value
+            }
+        )
+        (Json.field.required
+            { fieldName = "sender"
+            , toField = .sender
+            , description = Text.fields.event.sender
+            , coder = User.coder
+            }
+        )
+        (Json.field.required
+            { fieldName = "stateKey"
+            , toField = .stateKey
+            , description = Text.fields.event.stateKey
+            , coder = Json.string
+            }
+        )
+        (Json.field.required
+            { fieldName = "eventType"
+            , toField = .eventType
+            , description = Text.fields.event.eventType
+            , coder = Json.string
+            }
+        )
+
+
+getInviteEvent : { eventType : String, stateKey : String } -> Invite -> Maybe InviteEvent
+getInviteEvent { eventType, stateKey } invite =
+    invite.events
+        |> Dict.get eventType
+        |> Maybe.andThen (Dict.get stateKey)
+
+
+toList : Invite -> List InviteEvent
+toList invite =
+    invite.events
+        |> Dict.values
+        |> List.concatMap Dict.values

--- a/src/Internal/Values/Vault.elm
+++ b/src/Internal/Values/Vault.elm
@@ -43,7 +43,6 @@ import Internal.Config.Text as Text
 import Internal.Tools.Hashdict as Hashdict exposing (Hashdict)
 import Internal.Tools.Json as Json
 import Internal.Values.Room as Room exposing (Room)
-import Internal.Values.User as User exposing (User)
 import Recursion
 import Recursion.Fold
 

--- a/src/Matrix.elm
+++ b/src/Matrix.elm
@@ -3,7 +3,7 @@ module Matrix exposing
     , VaultUpdate, update, sync, logs
     , rooms, fromRoomId
     , getAccountData, setAccountData
-    , addAccessToken, sendMessageEvent, whoAmI
+    , addAccessToken, leave, sendMessageEvent, whoAmI
     )
 
 {-|
@@ -41,7 +41,7 @@ support a monolithic public registry. (:
 
 ## Debugging
 
-@docs addAccessToken, sendMessageEvent, whoAmI
+@docs addAccessToken, leave, sendMessageEvent, whoAmI
 
 -}
 
@@ -141,12 +141,30 @@ fromUsername { username, host, port_ } =
         |> Vault
 
 
-{-| Get a list of all the rooms that the user has joined.
+{-| Leave a room. This stops a user from participating in a room.
+
+If the user was already in the room, they will no longer be able to see new events in the room. If the room requires an invite to join, they will need to be re-invited before they can re-join.
+
+If the user was invited to the room, but had not joined, this call serves to reject the invite.
+
+The user will still be allowed to retrieve history from the room which they were previously allowed to see.
+
 -}
-rooms : Vault -> List Types.Room
-rooms (Vault vault) =
-    Envelope.mapList Internal.rooms vault
-        |> List.map Types.Room
+leave :
+    { reason : Maybe String
+    , roomId : String
+    , toMsg : Types.VaultUpdate -> msg
+    , vault : Vault
+    }
+    -> Cmd msg
+leave data =
+    case data.vault of
+        Vault vault ->
+            Api.leave vault
+                { reason = data.reason
+                , roomId = data.roomId
+                , toMsg = Types.VaultUpdate >> data.toMsg
+                }
 
 
 {-| The VaultUpdate is a complex type that helps update the Vault. However,
@@ -169,6 +187,14 @@ further. For example:
 logs : VaultUpdate -> List { channel : String, content : String }
 logs (VaultUpdate vu) =
     vu.logs
+
+
+{-| Get a list of all the rooms that the user has joined.
+-}
+rooms : Vault -> List Types.Room
+rooms (Vault vault) =
+    Envelope.mapList Internal.rooms vault
+        |> List.map Types.Room
 
 
 {-| Send a message event to a room.

--- a/src/Matrix.elm
+++ b/src/Matrix.elm
@@ -3,7 +3,7 @@ module Matrix exposing
     , VaultUpdate, update, sync, logs
     , rooms, fromRoomId
     , getAccountData, setAccountData
-    , addAccessToken, sendMessageEvent
+    , addAccessToken, sendMessageEvent, whoAmI
     )
 
 {-|
@@ -41,7 +41,7 @@ support a monolithic public registry. (:
 
 ## Debugging
 
-@docs addAccessToken, sendMessageEvent
+@docs addAccessToken, sendMessageEvent, whoAmI
 
 -}
 
@@ -253,3 +253,16 @@ update (VaultUpdate vu) (Vault vault) =
     vu.messages
         |> List.foldl (Envelope.update Internal.update) vault
         |> Vault
+
+
+{-| Get personal information about the vault, such as the user id, the device
+id or other vital information.
+
+When the vault logs in, it will automatically know this information. However,
+if you plug in an access token, the vault might not know. If you wish to ensure
+that such information is available, you can use this function to download that
+information.
+-}
+whoAmI : (VaultUpdate -> msg) -> Vault -> Cmd msg
+whoAmI toMsg (Vault vault) =
+    Api.whoAmI vault { toMsg = Types.VaultUpdate >> toMsg }

--- a/src/Matrix.elm
+++ b/src/Matrix.elm
@@ -262,6 +262,7 @@ When the vault logs in, it will automatically know this information. However,
 if you plug in an access token, the vault might not know. If you wish to ensure
 that such information is available, you can use this function to download that
 information.
+
 -}
 whoAmI : (VaultUpdate -> msg) -> Vault -> Cmd msg
 whoAmI toMsg (Vault vault) =

--- a/src/Matrix/Event.elm
+++ b/src/Matrix/Event.elm
@@ -118,7 +118,8 @@ redact :
     , reason : Maybe String
     , toMsg : Types.VaultUpdate -> msg
     , transactionId : String
-    } -> Cmd msg
+    }
+    -> Cmd msg
 redact data =
     case data.event of
         Event event ->

--- a/src/Matrix/Event.elm
+++ b/src/Matrix/Event.elm
@@ -1,5 +1,6 @@
 module Matrix.Event exposing
     ( Event, content, eventType, stateKey
+    , redact
     , eventId, roomId, sender, originServerTs
     , previousContent, redactedBecause
     )
@@ -18,6 +19,11 @@ events.
 @docs Event, content, eventType, stateKey
 
 
+## Actions
+
+@docs redact
+
+
 ## Metadata
 
 @docs eventId, roomId, sender, originServerTs
@@ -32,6 +38,7 @@ information isn't always applicable, it doesn't always exist.
 
 -}
 
+import Internal.Api.Main as Api
 import Internal.Values.Envelope as Envelope
 import Internal.Values.Event as Internal
 import Json.Encode
@@ -101,6 +108,28 @@ to see the previous content.
 previousContent : Event -> Maybe Json.Encode.Value
 previousContent (Event event) =
     Envelope.extract Internal.prevContent event
+
+
+{-| Redact a given event. This erases as much information from the event as
+possible.
+-}
+redact :
+    { event : Event
+    , reason : Maybe String
+    , toMsg : Types.VaultUpdate -> msg
+    , transactionId : String
+    } -> Cmd msg
+redact data =
+    case data.event of
+        Event event ->
+            Api.redact
+                event
+                { eventId = eventId data.event
+                , reason = data.reason
+                , roomId = roomId data.event
+                , toMsg = Types.VaultUpdate >> data.toMsg
+                , transactionId = data.transactionId
+                }
 
 
 {-| If the event has been redacted, the homeserver can display the event that

--- a/src/Matrix/Invite.elm
+++ b/src/Matrix/Invite.elm
@@ -1,0 +1,152 @@
+module Matrix.Invite exposing
+    ( Invite, accept, reject
+    , roomId, InviteEvent, get, events
+    , sender, stateKey, eventType, content
+    )
+
+{-|
+
+
+# Invites
+
+Sometimes, your user will be invited to a new room!
+This module offers you a few simple handles to deal with such invites -
+you can accept them, reject them or inspect them for further information.
+
+
+# Invitations
+
+@docs Invite, accept, reject
+
+
+# Exploring invitations
+
+Sometimes, you may want to display information about the room.
+
+Be careful though, anyone can invite you to any room! This means that room invites
+may contain offensive, shocking or other unwanted content that the user may not
+want to see.
+
+@docs roomId, InviteEvent, get, events
+
+Once you have the event you want, you can explore it with the following functions.
+
+@docs sender, stateKey, eventType, content
+
+-}
+
+import Internal.Api.Main as Api
+import Internal.Values.Envelope as Envelope
+import Internal.Values.Invite as Invite
+import Json.Encode as E
+import Types exposing (Invite(..), InviteEvent(..))
+
+
+type alias Invite =
+    Types.Invite
+
+
+type alias InviteEvent =
+    Types.InviteEvent
+
+
+{-| Accept the invite. As a result, the user joins the room.
+-}
+accept :
+    { invite : Invite
+    , reason : Maybe String
+    , toMsg : Types.VaultUpdate -> msg
+    }
+    -> Cmd msg
+accept data =
+    case data.invite of
+        Invite invite ->
+            Api.join
+                invite
+                { reason = data.reason
+                , roomId = roomId data.invite
+                , toMsg = Types.VaultUpdate >> data.toMsg
+                }
+
+
+{-| Determines the content of an event.
+-}
+content : InviteEvent -> E.Value
+content (InviteEvent inviteEvent) =
+    Envelope.extract .content inviteEvent
+
+
+{-| Determines the content of a state event.
+-}
+eventType : InviteEvent -> String
+eventType (InviteEvent inviteEvent) =
+    Envelope.extract .eventType inviteEvent
+
+
+{-| Get a list of all shared state events in the invite.
+-}
+events : Invite -> List InviteEvent
+events (Invite invite) =
+    Envelope.mapList Invite.toList invite
+        |> List.map Types.InviteEvent
+
+
+{-| Get a specific state event. This allows you to generate a previes of the
+room. Do keep in mind that most servers do not give ALL state events, so you
+might not have access to some state events.
+-}
+get : { eventType : String, invite : Invite, stateKey : String } -> Maybe InviteEvent
+get data =
+    case data.invite of
+        Invite invite ->
+            invite
+                |> Envelope.mapMaybe
+                    (Invite.getInviteEvent
+                        { eventType = data.eventType
+                        , stateKey = data.stateKey
+                        }
+                    )
+                |> Maybe.map Types.InviteEvent
+
+
+{-| Reject the invite. As a result, the room is informed that the user has
+decided not to join. If the room is private, the user can no longer join until
+they receive a new invite.
+-}
+reject :
+    { invite : Invite
+    , reason : Maybe String
+    , toMsg : Types.VaultUpdate -> msg
+    }
+    -> Cmd msg
+reject data =
+    case data.invite of
+        Invite invite ->
+            Api.leave
+                invite
+                { reason = data.reason
+                , roomId = roomId data.invite
+                , toMsg = Types.VaultUpdate >> data.toMsg
+                }
+
+
+{-| Get the room id of the room that the user is invited to.
+-}
+roomId : Invite -> String
+roomId (Invite invite) =
+    Envelope.extract .roomId invite
+
+
+{-| Determines the user that has originally sent this event.
+-}
+sender : InviteEvent -> Types.User
+sender (InviteEvent inviteEvent) =
+    Envelope.map .sender inviteEvent
+        |> Types.User
+
+
+{-| Determines the state key of a state event.
+-}
+stateKey : InviteEvent -> String
+stateKey (InviteEvent inviteEvent) =
+    Envelope.extract .stateKey inviteEvent

--- a/src/Matrix/Room.elm
+++ b/src/Matrix/Room.elm
@@ -20,6 +20,7 @@ where a group of users talk to each other.
 This module exposes various functions that help you inspect various aspects of
 a room.
 
+
 ## Actions
 
 @docs redact
@@ -148,7 +149,8 @@ redact :
     , room : Room
     , toMsg : Types.VaultUpdate -> msg
     , transactionId : String
-    } -> Cmd msg
+    }
+    -> Cmd msg
 redact data =
     case data.room of
         Room room ->

--- a/src/Matrix/Room.elm
+++ b/src/Matrix/Room.elm
@@ -1,5 +1,6 @@
 module Matrix.Room exposing
     ( Room, mostRecentEvents, roomId
+    , redact
     , getAccountData, setAccountData
     , sendMessageEvent, sendStateEvent
     , invite, kick, ban
@@ -18,6 +19,10 @@ where a group of users talk to each other.
 
 This module exposes various functions that help you inspect various aspects of
 a room.
+
+## Actions
+
+@docs redact
 
 
 ## Account data
@@ -131,6 +136,29 @@ kick data =
                 , roomId = roomId data.room
                 , toMsg = Types.VaultUpdate >> data.toMsg
                 , user = Envelope.getContent user
+                }
+
+
+{-| Redact an event in the room. This erases as much information from the event
+as possible.
+-}
+redact :
+    { eventId : String
+    , reason : Maybe String
+    , room : Room
+    , toMsg : Types.VaultUpdate -> msg
+    , transactionId : String
+    } -> Cmd msg
+redact data =
+    case data.room of
+        Room room ->
+            Api.redact
+                room
+                { eventId = data.eventId
+                , reason = data.reason
+                , roomId = roomId data.room
+                , toMsg = Types.VaultUpdate >> data.toMsg
+                , transactionId = data.transactionId
                 }
 
 

--- a/src/Matrix/Room.elm
+++ b/src/Matrix/Room.elm
@@ -1,6 +1,6 @@
 module Matrix.Room exposing
     ( Room, mostRecentEvents, roomId
-    , redact
+    , leave, redact
     , getAccountData, setAccountData
     , sendMessageEvent, sendStateEvent
     , invite, kick, ban
@@ -23,7 +23,7 @@ a room.
 
 ## Actions
 
-@docs redact
+@docs leave, redact
 
 
 ## Account data
@@ -137,6 +137,24 @@ kick data =
                 , roomId = roomId data.room
                 , toMsg = Types.VaultUpdate >> data.toMsg
                 , user = Envelope.getContent user
+                }
+
+
+{-| Leave a room.
+-}
+leave :
+    { reason : Maybe String
+    , room : Room
+    , toMsg : Types.VaultUpdate -> msg
+    }
+    -> Cmd msg
+leave data =
+    case data.room of
+        Room room ->
+            Api.leave room
+                { reason = data.reason
+                , roomId = roomId data.room
+                , toMsg = Types.VaultUpdate >> data.toMsg
                 }
 
 

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -1,4 +1,7 @@
-module Types exposing (Vault(..), Event(..), Room(..), User(..), VaultUpdate(..))
+module Types exposing
+    ( Vault(..), Event(..), Invite(..), Room(..), User(..), VaultUpdate(..)
+    , InviteEvent(..)
+    )
 
 {-| The Elm SDK uses a lot of records and values that are easy to manipulate.
 Yet, the [Elm design guidelines](https://package.elm-lang.org/help/design-guidelines#keep-tags-and-record-constructors-secret)
@@ -12,13 +15,14 @@ access their content directly.
 The opaque types are placed in a central module so all exposed modules can
 safely access all exposed data types without risking to create circular imports.
 
-@docs Vault, Event, Room, User, VaultUpdate
+@docs Vault, Event, Invite, Room, User, VaultUpdate
 
 -}
 
 import Internal.Api.Main as Api
 import Internal.Values.Envelope as Envelope
 import Internal.Values.Event as Event
+import Internal.Values.Invite as Invite
 import Internal.Values.Room as Room
 import Internal.Values.User as User
 import Internal.Values.Vault as Vault
@@ -28,6 +32,18 @@ import Internal.Values.Vault as Vault
 -}
 type Event
     = Event (Envelope.Envelope Event.Event)
+
+
+{-| Opaque type for Matrix Invite
+-}
+type Invite
+    = Invite (Envelope.Envelope Invite.Invite)
+
+
+{-| Opauqe type for Matrix InviteEvent
+-}
+type InviteEvent
+    = InviteEvent (Envelope.Envelope Invite.InviteEvent)
 
 
 {-| Opaque type for Matrix Room


### PR DESCRIPTION
With this pull request, (almost*) all API endpoints have been moved from the alpha implementation to the beta implementation.

The pull request also exposes a variety of new functions to the exposed library that will be available for use when the new version is accepted.

As a result,

- All relevant API endpoints have succesfully moved to the beta version.
- The underlying API library has been connected to the refactored data types.

This pull request adds the following exposed functions to the API:

- Leave rooms
- Use `whoami` to test an access token
- Redact events in a room
- Accept, reject & inspect invites