### PR TITLE
Decode invalid Matrix user IDs

### DIFF
--- a/src/Internal/Api/LoginWithUsernameAndPassword/Api.elm
+++ b/src/Internal/Api/LoginWithUsernameAndPassword/Api.elm
@@ -565,7 +565,7 @@ coderV1 =
             , description =
                 [ "The fully-qualified Matrix ID that has been registered."
                 ]
-            , coder = User.coder
+            , coder = User.strictCoder
             }
         )
 
@@ -613,7 +613,7 @@ coderV2 =
             , description =
                 [ "The fully-qualified Matrix ID that has been registered."
                 ]
-            , coder = User.coder
+            , coder = User.strictCoder
             }
         )
 
@@ -661,7 +661,7 @@ coderV3 =
             , description =
                 [ "The fully-qualified Matrix ID that has been registered."
                 ]
-            , coder = User.coder
+            , coder = User.strictCoder
             }
         )
 
@@ -709,7 +709,7 @@ coderV4 =
             , description =
                 [ "The fully-qualified Matrix ID that has been registered."
                 ]
-            , coder = User.coder
+            , coder = User.strictCoder
             }
         )
         (Json.field.optional.value
@@ -784,7 +784,7 @@ coderV5 =
             , description =
                 [ "The fully-qualified Matrix ID that has been registered."
                 ]
-            , coder = User.coder
+            , coder = User.strictCoder
             }
         )
         (Json.field.optional.value
@@ -859,7 +859,7 @@ coderV6 =
             , description =
                 [ "The fully-qualified Matrix ID that has been registered."
                 ]
-            , coder = User.coder
+            , coder = User.strictCoder
             }
         )
         (Json.field.optional.value

--- a/src/Internal/Api/Sync/V2.elm
+++ b/src/Internal/Api/Sync/V2.elm
@@ -705,14 +705,14 @@ updateTimeline { filter, nextBatch, roomId, since } mstate timeline =
 
         newEvents : List Event.Event
         newEvents =
-            List.map (toEvent roomId) timeline.events
+            List.filterMap (toEvent roomId) timeline.events
 
         prevState : StateManager
         prevState =
             mstate
                 |> Maybe.andThen .events
                 |> Maybe.withDefault []
-                |> List.map (toEvent roomId)
+                |> List.filterMap (toEvent roomId)
                 |> StateManager.fromList
 
         currentState : StateManager
@@ -772,7 +772,7 @@ updateTimeline { filter, nextBatch, roomId, since } mstate timeline =
         ]
 
 
-toEvent : String -> ClientEventWithoutRoomID -> Event.Event
+toEvent : String -> ClientEventWithoutRoomID -> Maybe Event.Event
 toEvent roomId event =
     Recursion.runRecursion
         (\ev ->
@@ -781,28 +781,32 @@ toEvent roomId event =
                     Recursion.recurseThen e
                         (\eo ->
                             Recursion.base
-                                { content = ev.content
-                                , eventId = ev.eventId
-                                , originServerTs = ev.originServerTs
-                                , roomId = roomId
-                                , sender = ev.sender
-                                , stateKey = ev.stateKey
-                                , eventType = ev.eventType
-                                , unsigned = toUnsigned (Just eo) ev.unsigned
-                                }
+                                (verifyLegality
+                                    { content = ev.content
+                                    , eventId = ev.eventId
+                                    , originServerTs = ev.originServerTs
+                                    , roomId = roomId
+                                    , sender = ev.sender
+                                    , stateKey = ev.stateKey
+                                    , eventType = ev.eventType
+                                    , unsigned = toUnsigned eo ev.unsigned
+                                    }
+                                )
                         )
 
                 Nothing ->
                     Recursion.base
-                        { content = ev.content
-                        , eventId = ev.eventId
-                        , originServerTs = ev.originServerTs
-                        , roomId = roomId
-                        , sender = ev.sender
-                        , stateKey = ev.stateKey
-                        , eventType = ev.eventType
-                        , unsigned = toUnsigned Nothing ev.unsigned
-                        }
+                        (verifyLegality
+                            { content = ev.content
+                            , eventId = ev.eventId
+                            , originServerTs = ev.originServerTs
+                            , roomId = roomId
+                            , sender = ev.sender
+                            , stateKey = ev.stateKey
+                            , eventType = ev.eventType
+                            , unsigned = toUnsigned Nothing ev.unsigned
+                            }
+                        )
         )
         event
 
@@ -832,3 +836,8 @@ toUnsigned ev unsigned =
             }
                 |> Event.UnsignedData
                 |> Just
+
+
+verifyLegality : Event.Event -> Maybe Event.Event
+verifyLegality =
+    PV.verifyLegality

--- a/src/Internal/Api/Sync/V3.elm
+++ b/src/Internal/Api/Sync/V3.elm
@@ -301,7 +301,7 @@ coderInviteState =
     PV.coderInviteState
 
 
-coderStrippedStateEvent : Json.Coder StrippedStateEvent
+coderStrippedStateEvent : Json.Coder (Maybe StrippedStateEvent)
 coderStrippedStateEvent =
     PV.coderStrippedStateEvent
 
@@ -374,7 +374,7 @@ coderState =
     PV.coderState
 
 
-coderClientEventWithoutRoomID : Json.Coder ClientEventWithoutRoomID
+coderClientEventWithoutRoomID : Json.Coder (Maybe ClientEventWithoutRoomID)
 coderClientEventWithoutRoomID =
     PV.coderClientEventWithoutRoomID
 
@@ -447,7 +447,7 @@ coderToDevice =
     PV.coderToDevice
 
 
-coderToDeviceEvent : Json.Coder ToDeviceEvent
+coderToDeviceEvent : Json.Coder (Maybe ToDeviceEvent)
 coderToDeviceEvent =
     PV.coderToDeviceEvent
 
@@ -584,7 +584,7 @@ updateTimeline =
     PV.updateTimeline
 
 
-toEvent : String -> ClientEventWithoutRoomID -> Maybe Event.Event
+toEvent : String -> ClientEventWithoutRoomID -> Event.Event
 toEvent =
     PV.toEvent
 
@@ -592,8 +592,3 @@ toEvent =
 toUnsigned : Maybe Event.Event -> Maybe UnsignedData -> Maybe Event.UnsignedData
 toUnsigned =
     PV.toUnsigned
-
-
-verifyLegality : Event.Event -> Maybe Event.Event
-verifyLegality =
-    PV.verifyLegality

--- a/src/Internal/Api/Sync/V3.elm
+++ b/src/Internal/Api/Sync/V3.elm
@@ -584,7 +584,7 @@ updateTimeline =
     PV.updateTimeline
 
 
-toEvent : String -> ClientEventWithoutRoomID -> Event.Event
+toEvent : String -> ClientEventWithoutRoomID -> Maybe Event.Event
 toEvent =
     PV.toEvent
 
@@ -592,3 +592,8 @@ toEvent =
 toUnsigned : Maybe Event.Event -> Maybe UnsignedData -> Maybe Event.UnsignedData
 toUnsigned =
     PV.toUnsigned
+
+
+verifyLegality : Event.Event -> Maybe Event.Event
+verifyLegality =
+    PV.verifyLegality

--- a/src/Internal/Api/WhoAmI/Api.elm
+++ b/src/Internal/Api/WhoAmI/Api.elm
@@ -159,7 +159,7 @@ coderV1 =
             { fieldName = "user_id"
             , toField = .user
             , description = [ "The user that owns the access token" ]
-            , coder = User.coder
+            , coder = User.strictCoder
             }
         )
 
@@ -184,7 +184,7 @@ coderV2 =
             { fieldName = "user_id"
             , toField = .user
             , description = [ "The user that owns the access token" ]
-            , coder = User.coder
+            , coder = User.strictCoder
             }
         )
 
@@ -217,6 +217,6 @@ coderV3 =
             { fieldName = "user_id"
             , toField = .user
             , description = [ "The user that owns the access token" ]
-            , coder = User.coder
+            , coder = User.strictCoder
             }
         )

--- a/src/Internal/Config/Text.elm
+++ b/src/Internal/Config/Text.elm
@@ -721,9 +721,16 @@ logs =
 
 {-| Function descriptions
 -}
-mappings : { itokenPTR : TypeDocs }
+mappings : { eventDecoder : TypeDocs, itokenPTR : TypeDocs }
 mappings =
-    { itokenPTR =
+    { eventDecoder =
+        { name = "Safe event decoding"
+        , description =
+            [ "Most Synapse servers allow invalid events to be sent over federation."
+            , "For this reason, each event is individually decoded, and invalid events are discarded."
+            ]
+        }
+    , itokenPTR =
         { name = "ITokenPTR init"
         , description =
             [ "Converts an optional string to an Itoken pointer."

--- a/src/Internal/Values/Context.elm
+++ b/src/Internal/Values/Context.elm
@@ -233,7 +233,7 @@ coder =
             { fieldName = "user"
             , toField = .user
             , description = Text.fields.context.user
-            , coder = User.coder
+            , coder = User.strictCoder
             }
         )
         (Json.field.optional.value

--- a/src/Internal/Values/Event.elm
+++ b/src/Internal/Values/Event.elm
@@ -114,7 +114,7 @@ coder =
             { fieldName = "sender"
             , toField = .sender
             , description = Text.fields.event.sender
-            , coder = User.coder
+            , coder = User.strictCoder
             }
         )
         (Json.field.optional.value

--- a/src/Internal/Values/Invite.elm
+++ b/src/Internal/Values/Invite.elm
@@ -13,6 +13,7 @@ might be relevant to them.
 
 import FastDict as Dict exposing (Dict)
 import Internal.Config.Text as Text
+import Internal.Grammar.UserId as UserId
 import Internal.Tools.Json as Json
 import Internal.Values.User as User exposing (User)
 
@@ -33,19 +34,23 @@ type alias InviteEvent =
 
 addInviteEvent : InviteEvent -> Invite -> Invite
 addInviteEvent event invite =
-    { invite
-        | events =
-            Dict.update event.eventType
-                (\mdict ->
-                    case mdict of
-                        Just dict ->
-                            Just (Dict.insert event.stateKey event dict)
+    if UserId.isIllegal event.sender then
+        invite
 
-                        Nothing ->
-                            Just (Dict.singleton event.stateKey event)
-                )
-                invite.events
-    }
+    else
+        { invite
+            | events =
+                Dict.update event.eventType
+                    (\mdict ->
+                        case mdict of
+                            Just dict ->
+                                Just (Dict.insert event.stateKey event dict)
+
+                            Nothing ->
+                                Just (Dict.singleton event.stateKey event)
+                    )
+                    invite.events
+        }
 
 
 {-| Define how an invite is encoded in JSON.

--- a/src/Internal/Values/Invite.elm
+++ b/src/Internal/Values/Invite.elm
@@ -99,7 +99,7 @@ coderEvent =
             { fieldName = "sender"
             , toField = .sender
             , description = Text.fields.event.sender
-            , coder = User.coder
+            , coder = User.strictCoder
             }
         )
         (Json.field.required

--- a/src/Internal/Values/User.elm
+++ b/src/Internal/Values/User.elm
@@ -61,7 +61,11 @@ coder =
                     P.succeed
                         ( name
                         , if UserId.isHistorical name then
-                            [ log.warn "Historical user found"
+                            [ log.warn ("Historical user found: " ++ UserId.toString name)
+                            ]
+
+                          else if UserId.isIllegal name then
+                            [ log.warn ("Invalid user found: " ++ UserId.toString name)
                             ]
 
                           else

--- a/tests/Test/Values/Timeline.elm
+++ b/tests/Test/Values/Timeline.elm
@@ -4,13 +4,13 @@ import Expect
 import Fuzz exposing (Fuzzer)
 import Internal.Filter.Timeline as Filter
 import Internal.Tools.Json as Json
+import Internal.Values.StateManager as StateManager
 import Internal.Values.Timeline as Timeline exposing (Batch, Timeline)
 import Json.Decode as D
 import Json.Encode as E
 import Test exposing (..)
 import Test.Filter.Timeline as TestFilter
 import Test.Values.StateManager as TestStateManager
-import Internal.Values.StateManager as StateManager
 
 
 fuzzer : Fuzzer Timeline


### PR DESCRIPTION
As referenced in [an issue on the Synapse repository](https://github.com/element-hq/synapse/issues/17740), Synapse servers do not sanitize `sender` fields and hence allow invalid users to exist. Examples are `@:example.org` and `@🐈:example.org`. As a result, Synapse servers cannot send valid initial sync requests to any user that is a member of any one room where an unsanitized invalid user ID has sent at least one state event.

Given that an outright majority of users resides on Synapse and similar servers that permit unsanitized user IDs over federation, this pull request adapts by decoding events individually, and then filtering the ones that contain invalid contents.

